### PR TITLE
feat(errors): add function and let-binding context to error messages

### DIFF
--- a/compiler/src/checker/mod.rs
+++ b/compiler/src/checker/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 
 use crate::core::{self, IntType, IntWidth, Lvl, Prim};
 use crate::parser::ast::{self, Phase};
@@ -185,6 +185,27 @@ fn elaborate_ty<'src, 'core>(
     }
 }
 
+/// Elaborate the signature (parameter types + return type) of a single function.
+fn elaborate_sig<'src, 'core>(
+    arena: &'core bumpalo::Bump,
+    func: &ast::Function<'src>,
+) -> Result<core::FunSig<'core>> {
+    let params: &'core [(&'core str, &'core core::Term<'core>)] =
+        arena.alloc_slice_try_fill_iter(func.params.iter().map(|p| -> Result<_> {
+            let param_name: &'core str = arena.alloc_str(p.name.as_str());
+            let param_ty = elaborate_ty(arena, func.phase, p.ty)?;
+            Ok((param_name, param_ty))
+        }))?;
+
+    let ret_ty = elaborate_ty(arena, func.phase, func.ret_ty)?;
+
+    Ok(core::FunSig {
+        params,
+        ret_ty,
+        phase: func.phase,
+    })
+}
+
 /// Pass 1: collect all top-level function signatures into a globals table.
 ///
 /// Type annotations on parameters and return types are elaborated here so that
@@ -203,24 +224,9 @@ pub(crate) fn collect_signatures<'src, 'core>(
             return Err(anyhow!("duplicate function name `{name}`"));
         }
 
-        // Elaborate parameter types in the function's own phase
-        let params: &'core [(&'core str, &'core core::Term<'core>)] = arena
-            .alloc_slice_try_fill_iter(func.params.iter().map(|p| -> Result<_> {
-                let param_name: &'core str = arena.alloc_str(p.name.as_str());
-                let param_ty = elaborate_ty(arena, func.phase, p.ty)?;
-                Ok((param_name, param_ty))
-            }))?;
+        let sig = elaborate_sig(arena, func).with_context(|| format!("in function `{name}`"))?;
 
-        let ret_ty = elaborate_ty(arena, func.phase, func.ret_ty)?;
-
-        globals.insert(
-            name,
-            core::FunSig {
-                params,
-                ret_ty,
-                phase: func.phase,
-            },
-        );
+        globals.insert(name, sig);
     }
 
     Ok(globals)
@@ -246,7 +252,8 @@ fn elaborate_bodies<'src, 'core>(
             }
 
             // Elaborate the body, checking it against the declared return type.
-            let core_body = check(&mut ctx, sig.phase, func.body, sig.ret_ty)?;
+            let core_body = check(&mut ctx, sig.phase, func.body, sig.ret_ty)
+                .with_context(|| format!("in function `{name}`"))?;
 
             // Re-borrow sig from globals (ctx was consumed in the check above).
             // We need the sig fields for the Function; collect them before moving ctx.
@@ -634,10 +641,12 @@ where
     // Determine the binding type: use annotation if present, otherwise infer.
     let (core_expr, bind_ty) = if let Some(ann) = stmt.ty {
         let ty = elaborate_ty(ctx.arena, phase, ann)?;
-        let core_e = check(ctx, phase, stmt.expr, ty)?;
+        let core_e = check(ctx, phase, stmt.expr, ty)
+            .with_context(|| format!("in let binding `{}`", stmt.name.as_str()))?;
         (core_e, ty)
     } else {
-        infer(ctx, phase, stmt.expr)?
+        infer(ctx, phase, stmt.expr)
+            .with_context(|| format!("in let binding `{}`", stmt.name.as_str()))?
     };
 
     let bind_name: &'core str = ctx.arena.alloc_str(stmt.name.as_str());

--- a/compiler/src/checker/mod.rs
+++ b/compiler/src/checker/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 
 use crate::core::{self, IntType, IntWidth, Lvl, Prim};
 use crate::parser::ast::{self, Phase};

--- a/compiler/src/lexer/mod.rs
+++ b/compiler/src/lexer/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 #[cfg(test)]
 pub mod testutils;

--- a/compiler/src/lexer/mod.rs
+++ b/compiler/src/lexer/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 
 #[cfg(test)]
 pub mod testutils;
@@ -13,6 +13,12 @@ impl<'a> Name<'a> {
 
     pub fn as_str(self) -> &'a str {
         self.0
+    }
+}
+
+impl std::fmt::Display for Name<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/compiler/src/lexer/testutils.rs
+++ b/compiler/src/lexer/testutils.rs
@@ -1,6 +1,6 @@
-use crate::lexer::{KEYWORDS, Name, SYMBOLS, Token};
+use crate::lexer::{Name, Token, KEYWORDS, SYMBOLS};
 
-use bolero::generator::{TypeGenerator, ValueGenerator, any, one_of, one_value_of};
+use bolero::generator::{any, one_of, one_value_of, TypeGenerator, ValueGenerator};
 
 const IDENTIFIERS: &[&str] = &[
     "x", "y", "z", "foo", "bar", "baz", "add", "mul", "id", "f", "g", "h", "a", "b", "c", "n", "m",

--- a/compiler/src/lexer/testutils.rs
+++ b/compiler/src/lexer/testutils.rs
@@ -1,6 +1,6 @@
-use crate::lexer::{Name, Token, KEYWORDS, SYMBOLS};
+use crate::lexer::{KEYWORDS, Name, SYMBOLS, Token};
 
-use bolero::generator::{any, one_of, one_value_of, TypeGenerator, ValueGenerator};
+use bolero::generator::{TypeGenerator, ValueGenerator, any, one_of, one_value_of};
 
 const IDENTIFIERS: &[&str] = &[
     "x", "y", "z", "foo", "bar", "baz", "add", "mul", "id", "f", "g", "h", "a", "b", "c", "n", "m",

--- a/compiler/src/parser/mod.rs
+++ b/compiler/src/parser/mod.rs
@@ -136,7 +136,7 @@ where
     pub fn parse_program(&mut self) -> Result<Program<'a>> {
         let mut functions = Vec::new();
         while self.peek().is_some() {
-            let fun = self.parse_fn_def().context("parsing function definition")?;
+            let fun = self.parse_fn_def()?;
             functions.push(fun);
         }
         let functions = self.arena.alloc_slice_fill_iter(functions);
@@ -153,6 +153,11 @@ where
         self.take(Token::Fn).context("expected 'fn'")?;
         let name = self.take_ident().context("expected function name")?;
 
+        self.parse_fn_def_after_name(phase, name)
+            .with_context(|| format!("in function `{name}`"))
+    }
+
+    fn parse_fn_def_after_name(&mut self, phase: Phase, name: Name<'a>) -> Result<Function<'a>> {
         self.take(Token::LParen).context("expected '('")?;
         let params = self.parse_params()?;
         self.take(Token::RParen).context("expected ')'")?;
@@ -220,7 +225,7 @@ where
             .context("expected '=' in let binding")?;
         let expr = self
             .parse_expr()
-            .context("expected expression in let binding")?;
+            .with_context(|| format!("in let binding `{name}`"))?;
         self.take(Token::Semi)
             .context("expected ';' after let binding")?;
         Ok(Let { name, ty, expr })

--- a/compiler/tests/snap.rs
+++ b/compiler/tests/snap.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 /// Snapshot files are named `1_lex.txt`, `2_parse.txt`, `3_check.txt`, `6_stage.txt`
 /// (slots 4–5 are reserved for future passes). On success the file contains the phase
 /// output directly. On failure it begins with `ERROR` on the first line followed by
-/// the error message.
+/// the error message (full context chain).
 ///
 /// Later phases are skipped if an earlier phase fails.
 #[rstest]
@@ -28,7 +28,7 @@ fn snap(#[files("tests/snap/*/*/0_input.splic")] path: PathBuf) {
             .iter()
             .map(|t| format!("{t:?}\n"))
             .collect::<String>(),
-        Err(e) => format!("ERROR\n{e}\n"),
+        Err(e) => format!("ERROR\n{e:#}\n"),
     };
     expect_file![dir.join("1_lex.txt")].assert_eq(&lex_snap);
     let Ok(tokens) = lex_result else { return };
@@ -37,7 +37,7 @@ fn snap(#[files("tests/snap/*/*/0_input.splic")] path: PathBuf) {
     let parse_result = Parser::new(tokens.into_iter().map(Ok), &arena).parse_program();
     let parse_snap = match &parse_result {
         Ok(program) => format!("{program:#?}\n"),
-        Err(e) => format!("ERROR\n{e}\n"),
+        Err(e) => format!("ERROR\n{e:#}\n"),
     };
     expect_file![dir.join("2_parse.txt")].assert_eq(&parse_snap);
     let Ok(program) = parse_result else { return };
@@ -46,7 +46,7 @@ fn snap(#[files("tests/snap/*/*/0_input.splic")] path: PathBuf) {
     let check_result = elaborate_program(&arena, &program);
     let check_snap = match &check_result {
         Ok(core) => format!("{core}\n"),
-        Err(e) => format!("ERROR\n{e}\n"),
+        Err(e) => format!("ERROR\n{e:#}\n"),
     };
     expect_file![dir.join("3_check.txt")].assert_eq(&check_snap);
     let Ok(core_program) = check_result else {
@@ -58,7 +58,7 @@ fn snap(#[files("tests/snap/*/*/0_input.splic")] path: PathBuf) {
     let stage_result = unstage_program(&arena, &core_program);
     let stage_snap = match &stage_result {
         Ok(staged) => format!("{staged}\n"),
-        Err(e) => format!("ERROR\n{e}\n"),
+        Err(e) => format!("ERROR\n{e:#}\n"),
     };
     expect_file![dir.join("6_stage.txt")].assert_eq(&stage_snap);
 }

--- a/compiler/tests/snap/lex/binary_ops/2_parse.txt
+++ b/compiler/tests/snap/lex/binary_ops/2_parse.txt
@@ -1,2 +1,2 @@
 ERROR
-parsing function definition
+expected 'fn': expected Fn, got Ident("a")

--- a/compiler/tests/snap/lex/match/2_parse.txt
+++ b/compiler/tests/snap/lex/match/2_parse.txt
@@ -1,2 +1,2 @@
 ERROR
-parsing function definition
+expected 'fn': expected Fn, got Match

--- a/compiler/tests/snap/lex/primitives/2_parse.txt
+++ b/compiler/tests/snap/lex/primitives/2_parse.txt
@@ -1,2 +1,2 @@
 ERROR
-parsing function definition
+expected 'fn': expected Fn, got Ident("u0")

--- a/compiler/tests/snap/lex/staging/2_parse.txt
+++ b/compiler/tests/snap/lex/staging/2_parse.txt
@@ -1,2 +1,2 @@
 ERROR
-parsing function definition
+expected 'fn': expected Fn, got HashLParen

--- a/compiler/tests/snap/type_error/match_arm_type_mismatch/3_check.txt
+++ b/compiler/tests/snap/type_error/match_arm_type_mismatch/3_check.txt
@@ -1,2 +1,2 @@
 ERROR
-type mismatch
+in function `bad`: type mismatch

--- a/compiler/tests/snap/type_error/return_type_mismatch/3_check.txt
+++ b/compiler/tests/snap/type_error/return_type_mismatch/3_check.txt
@@ -1,2 +1,2 @@
 ERROR
-type mismatch
+in function `bad`: type mismatch

--- a/compiler/tests/snap/type_error/splice_non_lifted/3_check.txt
+++ b/compiler/tests/snap/type_error/splice_non_lifted/3_check.txt
@@ -1,2 +1,2 @@
 ERROR
-type mismatch
+in function `bad`: type mismatch

--- a/compiler/tests/snap/type_error/unannotated_let/3_check.txt
+++ b/compiler/tests/snap/type_error/unannotated_let/3_check.txt
@@ -1,2 +1,2 @@
 ERROR
-cannot infer type of a literal; add a type annotation
+in function `bad`: in let binding `x`: cannot infer type of a literal; add a type annotation

--- a/compiler/tests/snap/type_error/unbound_variable/3_check.txt
+++ b/compiler/tests/snap/type_error/unbound_variable/3_check.txt
@@ -1,2 +1,2 @@
 ERROR
-unbound variable `x`
+in function `bad`: unbound variable `x`


### PR DESCRIPTION
Errors now include the enclosing function name and let-binding name in the context chain, e.g. "in function `bad`: in let binding `x`: ...".