### PR TITLE
fix: validate that numeric literals fit their type

### DIFF
--- a/compiler/src/checker/mod.rs
+++ b/compiler/src/checker/mod.rs
@@ -766,7 +766,13 @@ pub fn check<'src, 'core>(
         // ------------------------------------------------------------------ Lit
         // Literals check against any integer type.
         ast::Term::Lit(n) => match expected {
-            core::Term::Prim(Prim::IntTy(it)) => Ok(ctx.alloc(core::Term::Lit(*n, *it))),
+            core::Term::Prim(Prim::IntTy(it)) => {
+                let width = it.width;
+                if *n > width.max_value() {
+                    return Err(anyhow!("literal `{n}` does not fit in type `{width}`"));
+                }
+                Ok(ctx.alloc(core::Term::Lit(*n, *it)))
+            }
             core::Term::Var(_)
             | core::Term::Prim(_)
             | core::Term::Lit(..)

--- a/compiler/src/checker/test/literal.rs
+++ b/compiler/src/checker/test/literal.rs
@@ -59,3 +59,39 @@ fn infer_lit_fails() {
     let term = src_arena.alloc(ast::Term::Lit(0));
     assert!(infer(&mut ctx, Phase::Meta, term).is_err());
 }
+
+// Test that literals exceeding the maximum value for their type are rejected.
+#[rstest::rstest]
+#[case(IntWidth::U0, 1)] // u0 max is 0
+#[case(IntWidth::U1, 2)] // u1 max is 1
+#[case(IntWidth::U8, 256)] // u8 max is 255
+#[case(IntWidth::U16, 65536)] // u16 max is 65535
+#[case(IntWidth::U32, 4294967296)] // u32 max is 4294967295
+fn check_lit_exceeds_max_fails(#[case] width: IntWidth, #[case] value: u64) {
+    let src_arena = bumpalo::Bump::new();
+    let core_arena = bumpalo::Bump::new();
+    let mut ctx = test_ctx(&core_arena);
+    let expected = core::Term::int_ty(width, Phase::Object);
+
+    let term = src_arena.alloc(ast::Term::Lit(value));
+    assert!(check(&mut ctx, Phase::Object, term, expected).is_err());
+}
+
+// Test that literals at the maximum value for their type succeed.
+#[rstest::rstest]
+#[case(IntWidth::U0, 0)]
+#[case(IntWidth::U1, 1)]
+#[case(IntWidth::U8, 255)]
+#[case(IntWidth::U16, 65535)]
+#[case(IntWidth::U32, 4294967295)]
+#[case(IntWidth::U64, 18446744073709551615)]
+fn check_lit_at_max_succeeds(#[case] width: IntWidth, #[case] value: u64) {
+    let src_arena = bumpalo::Bump::new();
+    let core_arena = bumpalo::Bump::new();
+    let mut ctx = test_ctx(&core_arena);
+    let expected = core::Term::int_ty(width, Phase::Object);
+
+    let term = src_arena.alloc(ast::Term::Lit(value));
+    let result = check(&mut ctx, Phase::Object, term, expected).expect("should check");
+    assert!(matches!(result, core::Term::Lit(v, _) if *v == value));
+}

--- a/compiler/src/core/prim.rs
+++ b/compiler/src/core/prim.rs
@@ -23,6 +23,18 @@ impl IntWidth {
             Self::U64 => "u64",
         }
     }
+
+    /// Returns the maximum value that can be represented in this integer width.
+    pub const fn max_value(self) -> u64 {
+        match self {
+            Self::U0 => 0,
+            Self::U1 => 1,
+            Self::U8 => u8::MAX as u64,
+            Self::U16 => u16::MAX as u64,
+            Self::U32 => u32::MAX as u64,
+            Self::U64 => u64::MAX,
+        }
+    }
 }
 
 impl std::fmt::Display for IntWidth {


### PR DESCRIPTION
When checking a literal against an integer type in the typechecker, verify that the value does not exceed the maximum value representable in that type (e.g., 256 cannot fit in u8). Add max_value() method to IntWidth and update the Lit checking logic to validate bounds.