### PR TITLE
refactor: rename eval module to staging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,18 @@ Splic is a Rust-based experimental programming language targeting zkVMs, built o
 
 ```
 splic/
-├── compiler/          # Main compiler crate
+├── compiler/          # Main compiler library crate
+│   └── src/
+│       ├── lexer/     # Tokenization
+│       ├── parser/    # Parsing (string → AST)
+│       ├── checker/   # Type checking, elaboration, dependent types (uses NbE)
+│       ├── core/      # Core language abstractions
+│       ├── staging/   # Meta-level staging (NbE-based code generation)
+│       └── common/    # Shared utilities
+├── cli/               # CLI binary crate (depends on compiler)
 ├── docs/              # Documentation
+│   ├── README.md      # Language design and user-facing docs
+│   └── bs/            # Implementation notes and proposals
 ├── Cargo.toml         # Workspace configuration
 └── Cargo.lock         # Dependency lock file
 ```
@@ -59,10 +69,11 @@ cargo bolero test           # Run bolero fuzz tests
 ## Testing & Quality
 
 ### Test Structure
-- Tests located in `compiler/src/test/`
+- Unit tests located throughout `compiler/src/` in `test` modules (e.g., `compiler/src/lexer/test/`, `compiler/src/parser/test/`)
+- Integration tests in `compiler/tests/`
 - Uses **rstest** for parameterized tests
 - Snapshot testing with **expect-test** (diff output may show ANSI color codes which can be misleading - if colors appear in the diff, run `UPDATE_EXPECT=1 cargo test` to regenerate snapshots and verify actual state)
-- Fuzz tests in `fuzz.rs`
+- Fuzz tests with **bolero** in component `test` modules
 - Note: When adding new `.input.txt` test files, run `cargo clean -p splic-compiler` first to ensure they're picked up by the test framework
 
 ### Clippy
@@ -85,15 +96,11 @@ The project enforces a curated set of lints beyond Clippy defaults — see `[wor
 - Use `bumpalo` arena allocator wherever practical
 - For arena-allocated structures, refer to other objects using plain references rather than `Box`
 - In NbE (semantic evaluation), use slices `&'a [Value<'a>]` for environment snapshots captured in closures, not vectors
-- Keep mutable working environments (`Vec<Value>`) on the stack; snapshot them to the arena only at closure creation time
 
 ### 2LTT Patterns
 - No syntactic separation between type-level and term-level expressions
 - Quotations (`#(e)`, `#{...}`) and splices (`$(e)`, `${...}`) for metaprogramming
 - Lifting with `[[e]]`
-- `infer` returns `(&Term, Value)` — term **and** its type; never reconstruct types from elaborated terms
-- Use `check_universe(ctx, phase, term)` to check a term is a type; do not infer then check the universe
-- The canonical reference for the elaborator is [AndrasKovacs/staged](https://github.com/AndrasKovacs/staged) (`Elaboration.hs`, `Evaluation.hs`)
 
 ## Documentation
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context as _, Result};
 use clap::{Parser, Subcommand};
-use splic_compiler::{checker, eval, lexer, parser};
+use splic_compiler::{checker, lexer, parser, staging};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -52,7 +52,7 @@ fn stage(file: &PathBuf) -> Result<()> {
     // Unstage into out_arena; core_arena is no longer needed after this.
     let out_arena = bumpalo::Bump::new();
     let staged =
-        eval::unstage_program(&out_arena, &core_program).context("failed to stage program")?;
+        staging::unstage_program(&out_arena, &core_program).context("failed to stage program")?;
     drop(core_arena);
 
     // Print the staged result, then out_arena is dropped at end of scope.

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod checker;
 pub mod common;
 pub mod core;
-pub mod eval;
 pub mod lexer;
 pub mod parser;
+pub mod staging;

--- a/compiler/src/staging/mod.rs
+++ b/compiler/src/staging/mod.rs
@@ -505,9 +505,6 @@ fn eval_meta_match<'out, 'eval>(
 ///
 /// Used when splicing a `Code` value that was created at a shallower output depth into a deeper
 /// context: every free variable index must increase by the depth difference.
-///
-/// TODO(#29): This shifting step would be eliminated if object-level code used `NbE` with
-/// closures and De Bruijn levels (as in the Kovács reference impl) instead of raw terms.
 fn shift_free_ix<'out>(
     arena: &'out Bump,
     term: &'out Term<'out>,
@@ -723,7 +720,7 @@ pub fn unstage_program<'out, 'core>(
     // that exist only during evaluation and must not appear in the output.  Its lifetime
     // `'eval` is shorter than `'core`, so `'core` data is coercible to `'eval` via the
     // covariance of `Term`.
-    let eval_arena = Bump::new();
+    let eval_bump = Bump::new();
 
     let globals: Globals<'_> = program
         .functions
@@ -749,14 +746,14 @@ pub fn unstage_program<'out, 'core>(
 
             let staged_params = arena.alloc_slice_try_fill_iter(pi.params.iter().map(
                 |(n, ty)| -> Result<(&'out Name, &'out Term<'out>)> {
-                    let staged_ty = unstage_obj(arena, &eval_arena, &globals, &mut env, ty)?;
+                    let staged_ty = unstage_obj(arena, &eval_bump, &globals, &mut env, ty)?;
                     env.push_obj();
                     Ok((Name::new(arena.alloc_str(n.as_str())), staged_ty))
                 },
             ))?;
 
-            let staged_ret_ty = unstage_obj(arena, &eval_arena, &globals, &mut env, pi.body_ty)?;
-            let staged_body = unstage_obj(arena, &eval_arena, &globals, &mut env, f.body)?;
+            let staged_ret_ty = unstage_obj(arena, &eval_bump, &globals, &mut env, pi.body_ty)?;
+            let staged_body = unstage_obj(arena, &eval_bump, &globals, &mut env, f.body)?;
 
             Ok(Function {
                 name: Name::new(arena.alloc_str(f.name.as_str())),

--- a/compiler/tests/snap.rs
+++ b/compiler/tests/snap.rs
@@ -2,7 +2,7 @@ use bumpalo::Bump;
 use expect_test::expect_file;
 use rstest::rstest;
 use splic_compiler::{
-    checker::elaborate_program, eval::unstage_program, lexer::Lexer, parser::Parser,
+    checker::elaborate_program, lexer::Lexer, parser::Parser, staging::unstage_program,
 };
 use std::path::PathBuf;
 


### PR DESCRIPTION
- Rename eval module to staging (more accurately reflects its role in meta-level code generation)
- Update AGENTS.md project structure docs with compiler module layout
- Clarify that NbE is used in both checker (dependent types) and staging
- Add cli crate and docs subdirectories to project structure
- Update test structure documentation to reflect distributed unit tests