### PR TITLE
refactor: move de Bruijn index/level types to common module

### DIFF
--- a/compiler/src/checker/ctx.rs
+++ b/compiler/src/checker/ctx.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use crate::core::{self, value};
 use crate::common::de_bruijn;
+use crate::core::{self, value};
 
 /// Elaboration context.
 ///
@@ -97,7 +97,10 @@ impl<'core, 'globals> Ctx<'core, 'globals> {
 
     /// Look up a variable by name, returning its (index, type as Value).
     /// Searches from the most recently pushed variable inward to handle shadowing.
-    pub fn lookup_local(&self, name: &'_ core::Name) -> Option<(de_bruijn::Ix, &value::Value<'core>)> {
+    pub fn lookup_local(
+        &self,
+        name: &'_ core::Name,
+    ) -> Option<(de_bruijn::Ix, &value::Value<'core>)> {
         for (i, local_name) in self.names.iter().enumerate().rev() {
             if *local_name == name {
                 let ix = de_bruijn::Lvl::new(i).ix_at_depth(self.depth());

--- a/compiler/src/checker/ctx.rs
+++ b/compiler/src/checker/ctx.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use crate::core::{self, Ix, Lvl, value};
+use crate::core::{self, value};
+use crate::common::de_bruijn;
 
 /// Elaboration context.
 ///
@@ -54,9 +55,9 @@ impl<'core, 'globals> Ctx<'core, 'globals> {
         self.arena.alloc_slice_fill_iter(items)
     }
 
-    /// Current De Bruijn level / locals stack depth — always equal to `env.len()`.
-    pub const fn depth(&self) -> Lvl {
-        Lvl(self.env.len())
+    /// Current De Bruijn depth — always equal to `env.len()`.
+    pub const fn depth(&self) -> de_bruijn::Depth {
+        de_bruijn::Depth::new(self.env.len())
     }
 
     /// Push a local variable onto the context, given its type as a term.
@@ -69,7 +70,7 @@ impl<'core, 'globals> Ctx<'core, 'globals> {
     /// Push a local variable onto the context, given its type as a Value.
     /// The variable itself is a fresh rigid (neutral) variable — use for lambda/pi params.
     pub fn push_local_val(&mut self, name: &'core core::Name, ty_val: value::Value<'core>) {
-        self.env.push(value::Value::Rigid(self.depth()));
+        self.env.push(value::Value::Rigid(self.depth().as_lvl()));
         self.types.push(ty_val);
         self.names.push(name);
     }
@@ -96,10 +97,10 @@ impl<'core, 'globals> Ctx<'core, 'globals> {
 
     /// Look up a variable by name, returning its (index, type as Value).
     /// Searches from the most recently pushed variable inward to handle shadowing.
-    pub fn lookup_local(&self, name: &'_ core::Name) -> Option<(Ix, &value::Value<'core>)> {
+    pub fn lookup_local(&self, name: &'_ core::Name) -> Option<(de_bruijn::Ix, &value::Value<'core>)> {
         for (i, local_name) in self.names.iter().enumerate().rev() {
             if *local_name == name {
-                let ix = Lvl(i).ix_at_depth(self.depth());
+                let ix = de_bruijn::Lvl::new(i).ix_at_depth(self.depth());
                 let ty = self
                     .types
                     .get(i)

--- a/compiler/src/checker/ctx.rs
+++ b/compiler/src/checker/ctx.rs
@@ -103,7 +103,7 @@ impl<'core, 'globals> Ctx<'core, 'globals> {
     ) -> Option<(de_bruijn::Ix, &value::Value<'core>)> {
         for (i, local_name) in self.names.iter().enumerate().rev() {
             if *local_name == name {
-                let ix = de_bruijn::Lvl::new(i).ix_at_depth(self.depth());
+                let ix = de_bruijn::Lvl::new(i).ix_at(self.depth());
                 let ty = self
                     .types
                     .get(i)

--- a/compiler/src/checker/infer.rs
+++ b/compiler/src/checker/infer.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result, anyhow, bail, ensure};
 
-use crate::core::{self, IntType, IntWidth, Lam, Phase, Pi, Prim, value};
 use crate::common::de_bruijn;
+use crate::core::{self, IntType, IntWidth, Lam, Phase, Pi, Prim, value};
 use crate::parser::ast;
 
 use super::{Ctx, builtin_prim_ty};
@@ -709,7 +709,8 @@ fn check_val_impl<'src, 'core>(
             // have the expected type as a core term, refine per-arm by re-evaluating
             // that term with the arm's literal substituted for the scrutinee variable.
             let scrut_val = ctx.eval(core_scrutinee);
-            let scrut_refine: Option<(de_bruijn::Lvl, IntType)> = match (&scrut_val, &scrut_ty_val) {
+            let scrut_refine: Option<(de_bruijn::Lvl, IntType)> = match (&scrut_val, &scrut_ty_val)
+            {
                 (value::Value::Rigid(lvl), value::Value::Prim(Prim::IntTy(it))) => {
                     Some((*lvl, *it))
                 }

--- a/compiler/src/checker/infer.rs
+++ b/compiler/src/checker/infer.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context as _, Result, anyhow, bail, ensure};
 
-use crate::core::{self, IntType, IntWidth, Lam, Lvl, Phase, Pi, Prim, value};
+use crate::core::{self, IntType, IntWidth, Lam, Phase, Pi, Prim, value};
+use crate::common::de_bruijn;
 use crate::parser::ast;
 
 use super::{Ctx, builtin_prim_ty};
@@ -677,8 +678,9 @@ fn check_val_impl<'src, 'core>(
                      than the expected function type"
                 );
                 elaborated_params.push((param_name, annotated_ty));
+                let lvl = ctx.depth().as_lvl();
                 ctx.push_local_val(param_name, expected_domain);
-                arg_vals.push(value::Value::Rigid(Lvl(ctx.depth().0 - 1)));
+                arg_vals.push(value::Value::Rigid(lvl));
             }
 
             let body_ty_val = value::inst_n(ctx.arena, &vpi.ret_closure, &arg_vals);
@@ -707,7 +709,7 @@ fn check_val_impl<'src, 'core>(
             // have the expected type as a core term, refine per-arm by re-evaluating
             // that term with the arm's literal substituted for the scrutinee variable.
             let scrut_val = ctx.eval(core_scrutinee);
-            let scrut_refine: Option<(Lvl, IntType)> = match (&scrut_val, &scrut_ty_val) {
+            let scrut_refine: Option<(de_bruijn::Lvl, IntType)> = match (&scrut_val, &scrut_ty_val) {
                 (value::Value::Rigid(lvl), value::Value::Prim(Prim::IntTy(it))) => {
                     Some((*lvl, *it))
                 }
@@ -722,7 +724,7 @@ fn check_val_impl<'src, 'core>(
                         let arm_expected = match (&scrut_refine, &core_pat, expected_term) {
                             (Some((lvl, int_ty)), core::Pat::Lit(n), Some(ety)) => {
                                 let mut env = ctx.env.clone();
-                                *env.get_mut(lvl.0)
+                                *env.get_mut(lvl.as_usize())
                                     .expect("scrutinee level must be in scope") =
                                     value::Value::Lit(*n, *int_ty);
                                 value::eval(ctx.arena, &env, ety)

--- a/compiler/src/checker/test/context.rs
+++ b/compiler/src/checker/test/context.rs
@@ -38,7 +38,7 @@ fn variable_lookup_after_push() {
     let (ix, ty) = ctx
         .lookup_local(core::Name::new("x"))
         .expect("x should be in scope");
-    assert_eq!(ix, Ix(0));
+    assert_eq!(ix, de_bruijn::Ix::new(0));
     assert!(matches!(
         ty,
         value::Value::Prim(Prim::IntTy(IntType {
@@ -62,7 +62,7 @@ fn variable_lookup_with_multiple_locals() {
     let (ix_y, ty_y) = ctx
         .lookup_local(core::Name::new("y"))
         .expect("y should be in scope");
-    assert_eq!(ix_y, Ix(0));
+    assert_eq!(ix_y, de_bruijn::Ix::new(0));
     assert!(matches!(
         ty_y,
         value::Value::Prim(Prim::IntTy(IntType {
@@ -74,7 +74,7 @@ fn variable_lookup_with_multiple_locals() {
     let (ix_x, ty_x) = ctx
         .lookup_local(core::Name::new("x"))
         .expect("x should be in scope");
-    assert_eq!(ix_x, Ix(1));
+    assert_eq!(ix_x, de_bruijn::Ix::new(1));
     assert!(matches!(
         ty_x,
         value::Value::Prim(Prim::IntTy(IntType {
@@ -98,7 +98,7 @@ fn variable_shadowing() {
     let (ix, ty) = ctx
         .lookup_local(core::Name::new("x"))
         .expect("x should be in scope");
-    assert_eq!(ix, Ix(0));
+    assert_eq!(ix, de_bruijn::Ix::new(0));
     assert!(matches!(
         ty,
         value::Value::Prim(Prim::IntTy(IntType {
@@ -114,13 +114,13 @@ fn context_depth() {
     let mut ctx = test_ctx(&arena);
     let u64_term = &core::Term::U64_META;
 
-    assert_eq!(ctx.depth(), Lvl(0));
+    assert_eq!(ctx.depth(), de_bruijn::Depth::ZERO);
     ctx.push_local(core::Name::new("x"), u64_term);
-    assert_eq!(ctx.depth(), Lvl(1));
+    assert_eq!(ctx.depth(), de_bruijn::Depth::new(1));
     ctx.push_local(core::Name::new("y"), u64_term);
-    assert_eq!(ctx.depth(), Lvl(2));
+    assert_eq!(ctx.depth(), de_bruijn::Depth::new(2));
     ctx.pop_local();
-    assert_eq!(ctx.depth(), Lvl(1));
+    assert_eq!(ctx.depth(), de_bruijn::Depth::new(1));
 }
 
 #[test]
@@ -130,8 +130,8 @@ fn meta_variable_in_quote_is_ok() {
     let u64_term = &core::Term::U64_META;
     let lifted_u64 = ctx.lift_ty(u64_term);
     ctx.push_local(core::Name::new("x"), lifted_u64);
-    let x_var = arena.alloc(core::Term::Var(Ix(0)));
-    assert!(matches!(x_var, core::Term::Var(Ix(0))));
+    let x_var = arena.alloc(core::Term::Var(de_bruijn::Ix::new(0)));
+    assert_eq!(x_var, &core::Term::Var(de_bruijn::Ix::new(0)));
 }
 
 #[test]
@@ -140,14 +140,14 @@ fn object_variable_outside_quote_is_invalid() {
     let mut ctx = test_ctx(&arena);
     let u64_term = &core::Term::U64_META;
     ctx.push_local(core::Name::new("x"), u64_term);
-    assert_eq!(ctx.depth(), Lvl(1));
+    assert_eq!(ctx.depth(), de_bruijn::Depth::new(1));
 }
 
 #[test]
 fn phase_is_argument_not_context() {
     let arena = bumpalo::Bump::new();
     let ctx = test_ctx(&arena);
-    assert_eq!(ctx.depth(), Lvl(0));
+    assert_eq!(ctx.depth(), de_bruijn::Depth::ZERO);
 }
 
 #[test]
@@ -220,7 +220,7 @@ fn splice_inference_mirrors_inner() {
     let u64_term = &core::Term::U64_META;
     let lifted_u64 = ctx.lift_ty(u64_term);
     ctx.push_local(core::Name::new("x"), lifted_u64);
-    let x_var = arena.alloc(core::Term::Var(Ix(0)));
+    let x_var = arena.alloc(core::Term::Var(de_bruijn::Ix::new(0)));
     let spliced = arena.alloc(core::Term::Splice(x_var));
     assert!(matches!(spliced, core::Term::Splice(_)));
 }
@@ -230,7 +230,7 @@ fn let_binding_structure() {
     let arena = bumpalo::Bump::new();
     let u64_term = &core::Term::U64_META;
     let expr = arena.alloc(core::Term::Lit(42, IntType::U64_META));
-    let body = arena.alloc(core::Term::Var(Ix(0)));
+    let body = arena.alloc(core::Term::Var(de_bruijn::Ix::new(0)));
     let let_term = arena.alloc(core::Term::new_let(
         core::Name::new("x"),
         u64_term,
@@ -243,7 +243,7 @@ fn let_binding_structure() {
 #[test]
 fn match_with_literal_pattern() {
     let arena = bumpalo::Bump::new();
-    let scrutinee = arena.alloc(core::Term::Var(Ix(0)));
+    let scrutinee = arena.alloc(core::Term::Var(de_bruijn::Ix::new(0)));
     let body0 = arena.alloc(core::Term::Lit(0, IntType::U64_META));
     let body1 = arena.alloc(core::Term::Lit(1, IntType::U64_META));
 
@@ -265,8 +265,8 @@ fn match_with_literal_pattern() {
 #[test]
 fn match_with_binding_pattern() {
     let arena = bumpalo::Bump::new();
-    let scrutinee = arena.alloc(core::Term::Var(Ix(0)));
-    let body = arena.alloc(core::Term::Var(Ix(0)));
+    let scrutinee = arena.alloc(core::Term::Var(de_bruijn::Ix::new(0)));
+    let body = arena.alloc(core::Term::Var(de_bruijn::Ix::new(0)));
 
     let arm = core::Arm {
         pat: Pat::Bind(core::Name::new("n")),

--- a/compiler/src/checker/test/mod.rs
+++ b/compiler/src/checker/test/mod.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 
 use super::*;
 
-use crate::core::{self, IntType, IntWidth, Ix, Lvl, Name, Pat, Pi, Prim, value};
+use crate::core::{self, IntType, IntWidth, Name, Pat, Pi, Prim, value};
+use crate::common::de_bruijn;
 use crate::parser::ast::{self, BinOp, FunName, MatchArm, Phase};
 
 mod helpers;

--- a/compiler/src/checker/test/mod.rs
+++ b/compiler/src/checker/test/mod.rs
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 
 use super::*;
 
-use crate::core::{self, IntType, IntWidth, Name, Pat, Pi, Prim, value};
 use crate::common::de_bruijn;
+use crate::core::{self, IntType, IntWidth, Name, Pat, Pi, Prim, value};
 use crate::parser::ast::{self, BinOp, FunName, MatchArm, Phase};
 
 mod helpers;

--- a/compiler/src/checker/test/var.rs
+++ b/compiler/src/checker/test/var.rs
@@ -13,8 +13,8 @@ fn infer_var_in_scope_returns_its_type() {
 
     let term = src_arena.alloc(ast::Term::Var(ast::Name::new("x")));
     let (core_term, ty_val) = infer(&mut ctx, Phase::Meta, term).expect("should infer");
-    // With one local "x", infer returns Var(Ix(0)) — innermost (only) binder.
-    assert!(matches!(core_term, core::Term::Var(Ix(0))));
+    // With one local "x", infer returns Var(de_bruijn::Ix(0)) — innermost (only) binder.
+    assert_eq!(core_term, &core::Term::Var(de_bruijn::Ix::new(0)));
     assert!(matches!(
         ty_val,
         value::Value::Prim(Prim::IntTy(IntType {
@@ -48,8 +48,8 @@ fn infer_var_returns_correct_index() {
 
     let term = src_arena.alloc(ast::Term::Var(ast::Name::new("y")));
     let (core_term, _) = infer(&mut ctx, Phase::Meta, term).expect("should infer");
-    // "y" is innermost, so Ix(0).
-    assert!(matches!(core_term, core::Term::Var(Ix(0))));
+    // "y" is innermost, so de_bruijn::Ix(0).
+    assert_eq!(core_term, &core::Term::Var(de_bruijn::Ix::new(0)));
 }
 
 // Shadowing: the innermost binding wins.
@@ -65,8 +65,8 @@ fn infer_var_shadowed_returns_innermost() {
 
     let term = src_arena.alloc(ast::Term::Var(ast::Name::new("x")));
     let (core_term, ty_val) = infer(&mut ctx, Phase::Meta, term).expect("should infer");
-    // Innermost "x" is at Ix(0).
-    assert!(matches!(core_term, core::Term::Var(Ix(0))));
+    // Innermost "x" is at de_bruijn::Ix(0).
+    assert_eq!(core_term, &core::Term::Var(de_bruijn::Ix::new(0)));
     assert!(matches!(
         ty_val,
         value::Value::Prim(Prim::IntTy(IntType {

--- a/compiler/src/common/de_bruijn.rs
+++ b/compiler/src/common/de_bruijn.rs
@@ -1,0 +1,79 @@
+/// De Bruijn level (counts from the outermost binder, 0 = outermost)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Lvl(usize);
+
+impl Lvl {
+    pub const fn new(n: usize) -> Self {
+        Self(n)
+    }
+
+    #[must_use]
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn succ(self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    #[must_use]
+    pub const fn ix_at_depth(self, depth: Depth) -> Ix {
+        Ix(depth.0 - self.0 - 1)
+    }
+}
+
+/// De Bruijn index (counts from nearest enclosing binder, 0 = innermost)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Ix(usize);
+
+impl Ix {
+    pub const fn new(n: usize) -> Self {
+        Self(n)
+    }
+
+    #[must_use]
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn succ(self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    #[must_use]
+    pub const fn lvl_at_depth(self, depth: Depth) -> Self {
+        Self(depth.0 - self.0 - 1)
+    }
+}
+
+/// De Bruijn depth (counts the number of binders from outermost one, 0 = no binders).
+///
+/// Same as `Lvl` but used to count how many binders down the current expression is,
+/// not to index into environment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Depth(usize);
+
+impl Depth {
+    pub const ZERO: Self = Self(0);
+
+    pub const fn new(n: usize) -> Self {
+        Self(n)
+    }
+
+    #[must_use]
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn as_lvl(self) -> Lvl {
+        Lvl::new(self.0)
+    }
+
+    #[must_use]
+    pub const fn succ(self) -> Self {
+        Self(self.0 + 1)
+    }
+}

--- a/compiler/src/common/de_bruijn.rs
+++ b/compiler/src/common/de_bruijn.rs
@@ -18,8 +18,12 @@ impl Lvl {
     }
 
     #[must_use]
-    pub const fn ix_at_depth(self, depth: Depth) -> Ix {
-        Ix(depth.0 - self.0 - 1)
+    pub fn ix_at_depth(self, depth: Depth) -> Ix {
+        let result = depth
+            .0
+            .checked_sub(self.0 + 1)
+            .expect("De Bruijn level out of range for depth (level must be < depth)");
+        Ix(result)
     }
 }
 
@@ -43,8 +47,12 @@ impl Ix {
     }
 
     #[must_use]
-    pub const fn lvl_at_depth(self, depth: Depth) -> Self {
-        Self(depth.0 - self.0 - 1)
+    pub fn lvl_at_depth(self, depth: Depth) -> Self {
+        let result = depth
+            .0
+            .checked_sub(self.0 + 1)
+            .expect("De Bruijn index out of range for depth (index must be < depth)");
+        Self(result)
     }
 }
 

--- a/compiler/src/common/de_bruijn.rs
+++ b/compiler/src/common/de_bruijn.rs
@@ -18,7 +18,7 @@ impl Lvl {
     }
 
     #[must_use]
-    pub fn ix_at_depth(self, depth: Depth) -> Ix {
+    pub fn ix_at(self, depth: Depth) -> Ix {
         let result = depth
             .0
             .checked_sub(self.0 + 1)
@@ -47,7 +47,7 @@ impl Ix {
     }
 
     #[must_use]
-    pub fn lvl_at_depth(self, depth: Depth) -> Self {
+    pub fn lvl_at(self, depth: Depth) -> Self {
         let result = depth
             .0
             .checked_sub(self.0 + 1)

--- a/compiler/src/common/de_bruijn.rs
+++ b/compiler/src/common/de_bruijn.rs
@@ -18,7 +18,7 @@ impl Lvl {
     }
 
     #[must_use]
-    pub fn ix_at(self, depth: Depth) -> Ix {
+    pub const fn ix_at(self, depth: Depth) -> Ix {
         let result = depth
             .0
             .checked_sub(self.0 + 1)
@@ -47,7 +47,7 @@ impl Ix {
     }
 
     #[must_use]
-    pub fn lvl_at(self, depth: Depth) -> Self {
+    pub const fn lvl_at(self, depth: Depth) -> Self {
         let result = depth
             .0
             .checked_sub(self.0 + 1)

--- a/compiler/src/common/mod.rs
+++ b/compiler/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod de_bruijn;
 pub mod name;
 pub mod operators;
 pub mod phase;

--- a/compiler/src/core/mod.rs
+++ b/compiler/src/core/mod.rs
@@ -3,49 +3,9 @@ mod prim;
 pub mod value;
 
 pub mod alpha_eq;
-pub use crate::common::{Name, Phase};
+pub use crate::common::{Name, Phase, de_bruijn};
 pub use alpha_eq::alpha_eq;
 pub use prim::{IntType, IntWidth, Prim};
-
-/// De Bruijn level (counts from the outermost binder, 0 = outermost)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Lvl(pub usize);
-
-impl Lvl {
-    pub const fn new(n: usize) -> Self {
-        Self(n)
-    }
-
-    #[must_use]
-    pub const fn succ(self) -> Self {
-        Self(self.0 + 1)
-    }
-
-    #[must_use]
-    pub const fn ix_at_depth(self, depth: Self) -> Ix {
-        Ix(depth.0 - self.0 - 1)
-    }
-}
-
-/// De Bruijn index (counts from nearest enclosing binder, 0 = innermost)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Ix(pub usize);
-
-impl Ix {
-    pub const fn new(n: usize) -> Self {
-        Self(n)
-    }
-
-    #[must_use]
-    pub const fn succ(self) -> Self {
-        Self(self.0 + 1)
-    }
-
-    #[must_use]
-    pub const fn lvl_at_depth(self, depth: Lvl) -> Self {
-        Self(depth.0 - self.0 - 1)
-    }
-}
 
 /// Match pattern in the core IR
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -148,7 +108,7 @@ pub struct Match<'a> {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Term<'a> {
     /// Local variable, identified by De Bruijn index (0 = innermost binder)
-    Var(Ix),
+    Var(de_bruijn::Ix),
     /// Built-in type or operation (not applied)
     Prim(Prim),
     /// Numeric literal with its integer type

--- a/compiler/src/core/pretty.rs
+++ b/compiler/src/core/pretty.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use crate::parser::ast::Phase;
+use crate::common::de_bruijn;
 
 use super::{Arm, Function, Name, Pat, Program, Term};
 
@@ -47,8 +48,8 @@ impl<'a> Term<'a> {
         match self {
             // ── Variable ─────────────────────────────────────────────────────────
             Term::Var(ix) => {
-                let lvl = ix.lvl_at_depth(super::Lvl(env.len()));
-                let i = lvl.0;
+                let lvl = ix.lvl_at_depth(de_bruijn::Depth::new(env.len()));
+                let i = lvl.as_usize();
                 let name = env
                     .get(i)
                     .expect("De Bruijn level out of environment bounds");

--- a/compiler/src/core/pretty.rs
+++ b/compiler/src/core/pretty.rs
@@ -48,7 +48,7 @@ impl<'a> Term<'a> {
         match self {
             // ── Variable ─────────────────────────────────────────────────────────
             Term::Var(ix) => {
-                let lvl = ix.lvl_at_depth(de_bruijn::Depth::new(env.len()));
+                let lvl = ix.lvl_at(de_bruijn::Depth::new(env.len()));
                 let i = lvl.as_usize();
                 let name = env
                     .get(i)

--- a/compiler/src/core/pretty.rs
+++ b/compiler/src/core/pretty.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use crate::parser::ast::Phase;
 use crate::common::de_bruijn;
+use crate::parser::ast::Phase;
 
 use super::{Arm, Function, Name, Pat, Program, Term};
 

--- a/compiler/src/core/value.rs
+++ b/compiler/src/core/value.rs
@@ -77,7 +77,7 @@ pub struct Closure<'a> {
 pub fn eval<'a>(arena: &'a Bump, env: &[Value<'a>], term: &'a Term<'a>) -> Value<'a> {
     match term {
         Term::Var(ix) => {
-            let lvl = ix.lvl_at_depth(de_bruijn::Depth::new(env.len()));
+            let lvl = ix.lvl_at(de_bruijn::Depth::new(env.len()));
             let i = lvl.as_usize();
             env.get(i)
                 .expect("De Bruijn index out of environment bounds")
@@ -287,7 +287,7 @@ fn quote_telescope<'a>(
 pub fn quote<'a>(arena: &'a Bump, depth: de_bruijn::Depth, val: &Value<'a>) -> &'a Term<'a> {
     match val {
         Value::Rigid(lvl) => {
-            let ix = lvl.ix_at_depth(depth);
+            let ix = lvl.ix_at(depth);
             arena.alloc(Term::Var(ix))
         }
         Value::Global(name) => arena.alloc(Term::Global(name)),

--- a/compiler/src/core/value.rs
+++ b/compiler/src/core/value.rs
@@ -261,7 +261,11 @@ fn quote_telescope<'a>(
     arena: &'a Bump,
     initial_depth: de_bruijn::Depth,
     params: &[(&'a Name, Closure<'a>)],
-) -> (Vec<(&'a Name, &'a Term<'a>)>, de_bruijn::Depth, Vec<Value<'a>>) {
+) -> (
+    Vec<(&'a Name, &'a Term<'a>)>,
+    de_bruijn::Depth,
+    Vec<Value<'a>>,
+) {
     let mut rigid_vals = Vec::new();
     let mut quoted_params = Vec::new();
     let mut d = initial_depth;

--- a/compiler/src/core/value.rs
+++ b/compiler/src/core/value.rs
@@ -7,8 +7,8 @@
 use bumpalo::Bump;
 
 use super::prim::IntType;
-use super::{Lam, Lvl, Name, Pat, Pi, Prim, Term};
-use crate::common::Phase;
+use super::{Lam, Name, Pat, Pi, Prim, Term};
+use crate::common::{Phase, de_bruijn};
 
 /// Working evaluation environment: index 0 = outermost binding, last = innermost.
 /// `Var(Ix(i))` maps to `env[env.len() - 1 - i]`.
@@ -18,7 +18,7 @@ pub type Env<'a> = Vec<Value<'a>>;
 #[derive(Clone, Debug)]
 pub enum Value<'a> {
     /// Neutral: stuck on a local variable (identified by De Bruijn level)
-    Rigid(Lvl),
+    Rigid(de_bruijn::Lvl),
     /// Neutral: global function reference (not inlined during type-checking)
     Global(&'a Name),
     /// Neutral: unapplied or partially applied primitive
@@ -77,8 +77,8 @@ pub struct Closure<'a> {
 pub fn eval<'a>(arena: &'a Bump, env: &[Value<'a>], term: &'a Term<'a>) -> Value<'a> {
     match term {
         Term::Var(ix) => {
-            let lvl = ix.lvl_at_depth(Lvl(env.len()));
-            let i = lvl.0;
+            let lvl = ix.lvl_at_depth(de_bruijn::Depth::new(env.len()));
+            let i = lvl.as_usize();
             env.get(i)
                 .expect("De Bruijn index out of environment bounds")
                 .clone()
@@ -259,9 +259,9 @@ pub fn inst_n<'a>(arena: &'a Bump, closure: &Closure<'a>, args: &[Value<'a>]) ->
 /// Returns the quoted parameters, final depth, and the rigid values built during the process.
 fn quote_telescope<'a>(
     arena: &'a Bump,
-    initial_depth: Lvl,
+    initial_depth: de_bruijn::Depth,
     params: &[(&'a Name, Closure<'a>)],
-) -> (Vec<(&'a Name, &'a Term<'a>)>, Lvl, Vec<Value<'a>>) {
+) -> (Vec<(&'a Name, &'a Term<'a>)>, de_bruijn::Depth, Vec<Value<'a>>) {
     let mut rigid_vals = Vec::new();
     let mut quoted_params = Vec::new();
     let mut d = initial_depth;
@@ -270,7 +270,7 @@ fn quote_telescope<'a>(
         let param_val = inst_n(arena, param_cl, &rigid_vals);
         let param_term = quote(arena, d, &param_val);
         quoted_params.push((*name, param_term));
-        rigid_vals.push(Value::Rigid(d));
+        rigid_vals.push(Value::Rigid(d.as_lvl()));
         d = d.succ();
     }
 
@@ -279,8 +279,8 @@ fn quote_telescope<'a>(
 
 /// Convert a value back to a term (for error reporting and definitional equality).
 ///
-/// `depth` is the current De Bruijn level (number of locally-bound variables in scope).
-pub fn quote<'a>(arena: &'a Bump, depth: Lvl, val: &Value<'a>) -> &'a Term<'a> {
+/// `depth` is the current De Bruijn depth (number of locally-bound variables in scope).
+pub fn quote<'a>(arena: &'a Bump, depth: de_bruijn::Depth, val: &Value<'a>) -> &'a Term<'a> {
     match val {
         Value::Rigid(lvl) => {
             let ix = lvl.ix_at_depth(depth);
@@ -334,7 +334,7 @@ pub fn quote<'a>(arena: &'a Bump, depth: Lvl, val: &Value<'a>) -> &'a Term<'a> {
 }
 
 /// Definitional equality: quote both values and compare structurally.
-pub fn val_eq<'a>(arena: &'a Bump, depth: Lvl, a: &Value<'a>, b: &Value<'a>) -> bool {
+pub fn val_eq<'a>(arena: &'a Bump, depth: de_bruijn::Depth, a: &Value<'a>, b: &Value<'a>) -> bool {
     let ta = quote(arena, depth, a);
     let tb = quote(arena, depth, b);
     super::alpha_eq::alpha_eq(ta, tb)

--- a/compiler/src/staging/mod.rs
+++ b/compiler/src/staging/mod.rs
@@ -4,8 +4,9 @@ use anyhow::{Result, anyhow, ensure};
 use bumpalo::Bump;
 
 use crate::core::{
-    Arm, Function, IntType, IntWidth, Ix, Lam, Lvl, Name, Pat, Pi, Prim, Program, Term,
+    Arm, Function, IntType, IntWidth, Lam, Name, Pat, Pi, Prim, Program, Term,
 };
+use crate::common::de_bruijn;
 use crate::parser::ast::Phase;
 
 // ── Value types ───────────────────────────────────────────────────────────────
@@ -28,7 +29,7 @@ enum MetaVal<'out, 'eval> {
     /// must be shifted by `(current_depth - depth)` before the term can be used.
     Code {
         term: &'out Term<'out>,
-        depth: usize,
+        depth: de_bruijn::Depth,
     },
     /// A type term passed as a type argument (dependent types: types are values).
     /// The type term itself is not inspected during evaluation.
@@ -38,7 +39,7 @@ enum MetaVal<'out, 'eval> {
         body: &'eval Term<'eval>,
         arity: usize,
         env: Vec<Binding<'out, 'eval>>,
-        obj_next: Lvl,
+        obj_depth: de_bruijn::Depth,
     },
 }
 
@@ -50,7 +51,7 @@ enum Binding<'out, 'eval> {
     /// A meta-level variable bound to a concrete `MetaVal`.
     Meta(MetaVal<'out, 'eval>),
     /// An object-level variable.
-    Obj(Lvl),
+    Obj(de_bruijn::Lvl),
 }
 
 /// Evaluation environment: a stack of bindings indexed by De Bruijn index.
@@ -60,24 +61,22 @@ enum Binding<'out, 'eval> {
 #[derive(Debug)]
 struct Env<'out, 'eval> {
     bindings: Vec<Binding<'out, 'eval>>,
-    obj_next: Lvl,
+    obj_depth: de_bruijn::Depth,
 }
 
 impl<'out, 'eval> Env<'out, 'eval> {
-    const fn new(obj_next: Lvl) -> Self {
+    const fn new(obj_depth: de_bruijn::Depth) -> Self {
         Env {
             bindings: Vec::new(),
-            obj_next,
+            obj_depth,
         }
     }
 
     /// Look up the binding for `Var(Ix(ix))`.
-    fn get_ix(&self, ix: Ix) -> &Binding<'out, 'eval> {
-        let i = self
-            .bindings
-            .len()
-            .checked_sub(1 + ix.0)
-            .expect("De Bruijn index out of environment bounds");
+    fn get_ix(&self, ix: de_bruijn::Ix) -> &Binding<'out, 'eval> {
+        let depth = de_bruijn::Depth::new(self.bindings.len());
+        let lvl = ix.lvl_at_depth(depth);
+        let i = lvl.as_usize();
         self.bindings
             .get(i)
             .expect("De Bruijn index out of environment bounds")
@@ -85,8 +84,8 @@ impl<'out, 'eval> Env<'out, 'eval> {
 
     /// Push an object-level binding.
     fn push_obj(&mut self) {
-        let lvl = self.obj_next;
-        self.obj_next = lvl.succ();
+        let lvl = self.obj_depth.as_lvl();
+        self.obj_depth = self.obj_depth.succ();
         self.bindings.push(Binding::Obj(lvl));
     }
 
@@ -99,11 +98,11 @@ impl<'out, 'eval> Env<'out, 'eval> {
     fn pop(&mut self) {
         match self.bindings.pop().expect("pop on empty environment") {
             Binding::Obj(_) => {
-                self.obj_next = Lvl::new(
-                    self.obj_next
-                        .0
+                self.obj_depth = de_bruijn::Depth::new(
+                    self.obj_depth
+                        .as_usize()
                         .checked_sub(1)
-                        .expect("obj_next underflow on pop"),
+                        .expect("obj_depth underflow on pop"),
                 );
             }
             Binding::Meta(_) => {}
@@ -136,8 +135,8 @@ fn eval_meta<'out, 'eval>(
         Term::Var(ix) => match env.get_ix(*ix) {
             Binding::Meta(v) => Ok(v.clone()),
             Binding::Obj(_) => unreachable!(
-                "object variable at index {} referenced in meta context (typechecker invariant)",
-                ix.0
+                "object variable at index {:?} referenced in meta context (typechecker invariant)",
+                ix
             ),
         },
 
@@ -149,7 +148,7 @@ fn eval_meta<'out, 'eval>(
             let def = globals
                 .get(name)
                 .unwrap_or_else(|| panic!("unknown global `{name}` during staging"));
-            Ok(global_to_closure(def, env.obj_next))
+            Ok(global_to_closure(def, env.obj_depth))
         }
 
         // ── Lambda ───────────────────────────────────────────────────────────
@@ -157,7 +156,7 @@ fn eval_meta<'out, 'eval>(
             body: lam.body,
             arity: lam.params.len(),
             env: env.bindings.clone(),
-            obj_next: env.obj_next,
+            obj_depth: env.obj_depth,
         }),
 
         // ── Application ──────────────────────────────────────────────────────
@@ -179,7 +178,7 @@ fn eval_meta<'out, 'eval>(
             let obj_term = unstage_obj(arena, eval_arena, globals, env, inner)?;
             Ok(MetaVal::Code {
                 term: obj_term,
-                depth: env.obj_next.0,
+                depth: env.obj_depth,
             })
         }
 
@@ -215,13 +214,13 @@ fn eval_meta<'out, 'eval>(
 /// Convert a global function definition into a closure value.
 const fn global_to_closure<'out, 'eval>(
     def: &GlobalDef<'eval>,
-    obj_next: Lvl,
+    obj_depth: de_bruijn::Depth,
 ) -> MetaVal<'out, 'eval> {
     MetaVal::Closure {
         body: def.body,
         arity: def.ty.params.len(),
         env: Vec::new(),
-        obj_next,
+        obj_depth,
     }
 }
 
@@ -238,12 +237,12 @@ fn apply_closure_n<'out, 'eval>(
             body,
             arity,
             env,
-            obj_next,
+            obj_depth,
         } => {
             debug_assert_eq!(args.len(), arity, "arity mismatch in apply_closure_n");
             let mut callee_env = Env {
                 bindings: env,
-                obj_next,
+                obj_depth,
             };
             for arg in args {
                 callee_env.push_meta(arg.clone());
@@ -386,7 +385,7 @@ fn eval_meta_prim<'out, 'eval>(
             let lit_term = arena.alloc(Term::Lit(n, IntType { width, phase }));
             Ok(MetaVal::Code {
                 term: lit_term,
-                depth: env.obj_next.0,
+                depth: env.obj_depth,
             })
         }
 
@@ -454,9 +453,9 @@ fn shift_free_ix<'out>(
         return term;
     }
     match term {
-        Term::Var(Ix(i)) => {
-            if *i >= cutoff {
-                arena.alloc(Term::Var(Ix(i + shift)))
+        Term::Var(ix) => {
+            if ix.as_usize() >= cutoff {
+                arena.alloc(Term::Var(de_bruijn::Ix::new(ix.as_usize() + shift)))
             } else {
                 term
             }
@@ -538,26 +537,26 @@ fn unstage_obj<'out, 'eval>(
         Term::Var(ix) => match env.get_ix(*ix) {
             Binding::Obj(out_lvl) => {
                 // Convert output level → De Bruijn index relative to current output depth.
-                let out_ix = Ix(env.obj_next.0 - out_lvl.0 - 1);
+                let out_ix = de_bruijn::Ix::new(env.obj_depth.as_usize() - out_lvl.as_usize() - 1);
                 Ok(arena.alloc(Term::Var(out_ix)))
             }
             Binding::Meta(MetaVal::Code { term, depth }) => {
-                Ok(shift_free_ix(arena, term, env.obj_next.0 - depth, 0))
+                Ok(shift_free_ix(arena, term, env.obj_depth.as_usize() - depth.as_usize(), 0))
             }
             Binding::Meta(MetaVal::Lit(_)) => unreachable!(
                 "integer meta variable at index {} referenced in object context \
                  (typechecker invariant)",
-                ix.0
+                ix.as_usize()
             ),
             Binding::Meta(MetaVal::Closure { .. }) => unreachable!(
-                "closure meta variable at index {} referenced in object context \
+                "closure meta variable at index {:?} referenced in object context \
                  (typechecker invariant)",
-                ix.0
+                ix
             ),
             Binding::Meta(MetaVal::Ty) => unreachable!(
-                "type meta variable at index {} referenced in object context \
+                "type meta variable at index {:?} referenced in object context \
                  (typechecker invariant)",
-                ix.0
+                ix
             ),
         },
 
@@ -588,7 +587,7 @@ fn unstage_obj<'out, 'eval>(
             let meta_val = eval_meta(arena, eval_arena, globals, env, inner)?;
             match meta_val {
                 MetaVal::Code { term, depth } => {
-                    Ok(shift_free_ix(arena, term, env.obj_next.0 - depth, 0))
+                    Ok(shift_free_ix(arena, term, env.obj_depth.as_usize() - depth.as_usize(), 0))
                 }
                 MetaVal::Lit(_) | MetaVal::Ty | MetaVal::Closure { .. } => {
                     unreachable!("splice evaluated to non-code value (typechecker invariant)")
@@ -681,7 +680,7 @@ pub fn unstage_program<'out, 'core>(
         .filter(|f| f.pi().phase == Phase::Object)
         .map(|f| -> Result<_> {
             let pi = f.pi();
-            let mut env = Env::new(Lvl::new(0));
+            let mut env = Env::new(de_bruijn::Depth::ZERO);
 
             let staged_params = arena.alloc_slice_try_fill_iter(pi.params.iter().map(
                 |(n, ty)| -> Result<(&'out Name, &'out Term<'out>)> {

--- a/compiler/src/staging/mod.rs
+++ b/compiler/src/staging/mod.rs
@@ -3,10 +3,8 @@ use std::collections::HashMap;
 use anyhow::{Result, anyhow, ensure};
 use bumpalo::Bump;
 
-use crate::core::{
-    Arm, Function, IntType, IntWidth, Lam, Name, Pat, Pi, Prim, Program, Term,
-};
 use crate::common::de_bruijn;
+use crate::core::{Arm, Function, IntType, IntWidth, Lam, Name, Pat, Pi, Prim, Program, Term};
 use crate::parser::ast::Phase;
 
 // ── Value types ───────────────────────────────────────────────────────────────
@@ -540,9 +538,12 @@ fn unstage_obj<'out, 'eval>(
                 let out_ix = de_bruijn::Ix::new(env.obj_depth.as_usize() - out_lvl.as_usize() - 1);
                 Ok(arena.alloc(Term::Var(out_ix)))
             }
-            Binding::Meta(MetaVal::Code { term, depth }) => {
-                Ok(shift_free_ix(arena, term, env.obj_depth.as_usize() - depth.as_usize(), 0))
-            }
+            Binding::Meta(MetaVal::Code { term, depth }) => Ok(shift_free_ix(
+                arena,
+                term,
+                env.obj_depth.as_usize() - depth.as_usize(),
+                0,
+            )),
             Binding::Meta(MetaVal::Lit(_)) => unreachable!(
                 "integer meta variable at index {} referenced in object context \
                  (typechecker invariant)",
@@ -586,9 +587,12 @@ fn unstage_obj<'out, 'eval>(
         Term::Splice(inner) => {
             let meta_val = eval_meta(arena, eval_arena, globals, env, inner)?;
             match meta_val {
-                MetaVal::Code { term, depth } => {
-                    Ok(shift_free_ix(arena, term, env.obj_depth.as_usize() - depth.as_usize(), 0))
-                }
+                MetaVal::Code { term, depth } => Ok(shift_free_ix(
+                    arena,
+                    term,
+                    env.obj_depth.as_usize() - depth.as_usize(),
+                    0,
+                )),
                 MetaVal::Lit(_) | MetaVal::Ty | MetaVal::Closure { .. } => {
                     unreachable!("splice evaluated to non-code value (typechecker invariant)")
                 }

--- a/compiler/src/staging/mod.rs
+++ b/compiler/src/staging/mod.rs
@@ -73,7 +73,7 @@ impl<'out, 'eval> Env<'out, 'eval> {
     /// Look up the binding for `Var(Ix(ix))`.
     fn get_ix(&self, ix: de_bruijn::Ix) -> &Binding<'out, 'eval> {
         let depth = de_bruijn::Depth::new(self.bindings.len());
-        let lvl = ix.lvl_at_depth(depth);
+        let lvl = ix.lvl_at(depth);
         let i = lvl.as_usize();
         self.bindings
             .get(i)


### PR DESCRIPTION
Create crate::common::de_bruijn module containing Ix, Lvl, and Depth types. Update all imports and usages throughout the codebase to use qualified names (de_bruijn::Ix, de_bruijn::Lvl, de_bruijn::Depth) for clarity. Add accessor methods (as_usize, as_lvl) and a Depth::ZERO constant for convenience.