### PR TITLE
More clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ trivially_copy_pass_by_ref = "deny"
 cast_possible_truncation = "deny"
 explicit_iter_loop = "deny"
 wildcard_enum_match_arm = "allow"
+single_match_else = "allow"
 indexing_slicing = "deny"
 self_named_module_files = "deny"
 precedence_bits = "deny"
@@ -47,6 +48,10 @@ wildcard_imports = "deny"
 enum_glob_use = "deny"
 cargo = { level = "deny", priority = -1 }
 cargo_common_metadata = "allow"
+pedantic = { level = "deny", priority = -1 }
+must_use_candidate = "allow"
+missing_panics_doc = "allow"
+missing_errors_doc = "allow"
 
 [profile.fuzz]
 inherits = "dev"

--- a/compiler/src/checker/infer.rs
+++ b/compiler/src/checker/infer.rs
@@ -8,6 +8,7 @@ use super::{Ctx, builtin_prim_ty};
 
 /// Infer the type of a surface term, returning both the elaborated core term
 /// and its type as a semantic value.
+#[expect(clippy::too_many_lines)]
 pub fn infer<'src, 'core>(
     ctx: &mut Ctx<'core, '_>,
     phase: Phase,
@@ -151,11 +152,10 @@ pub fn infer<'src, 'core>(
                 width: IntWidth::U1,
                 phase: op_int_ty.phase,
             }));
-            let core_args = ctx.alloc_slice([core_arg0, core_arg1]);
             Ok((
                 ctx.alloc(core::Term::new_app(
                     ctx.alloc(core::Term::Prim(prim)),
-                    core_args,
+                    ctx.alloc_slice([core_arg0, core_arg1]),
                 )),
                 result_ty,
             ))
@@ -501,6 +501,7 @@ pub fn check_val<'src, 'core>(
 
 /// Internal implementation — `expected_term` carries the original core term for the expected
 /// type, enabling dependent-type arm refinement (re-evaluating under a modified env).
+#[expect(clippy::too_many_lines)]
 fn check_val_impl<'src, 'core>(
     ctx: &mut Ctx<'core, '_>,
     phase: Phase,
@@ -542,12 +543,12 @@ fn check_val_impl<'src, 'core>(
                 | ast::BinOp::Ge
         ) =>
         {
+            use ast::BinOp;
             let int_ty = match &expected {
                 value::Value::Prim(Prim::IntTy(it)) => *it,
                 _ => bail!("primitive operation requires an integer type"),
             };
 
-            use ast::BinOp;
             let prim = match op {
                 BinOp::Add => Prim::Add(int_ty),
                 BinOp::Sub => Prim::Sub(int_ty),
@@ -568,10 +569,9 @@ fn check_val_impl<'src, 'core>(
             let core_arg0 = check(ctx, phase, lhs, expected_term)?;
             let core_arg1 = check(ctx, phase, rhs, expected_term)?;
 
-            let core_args = ctx.alloc_slice([core_arg0, core_arg1]);
             Ok(ctx.alloc(core::Term::new_app(
                 ctx.alloc(core::Term::Prim(prim)),
-                core_args,
+                ctx.alloc_slice([core_arg0, core_arg1]),
             )))
         }
 

--- a/compiler/src/checker/test/literal.rs
+++ b/compiler/src/checker/test/literal.rs
@@ -64,9 +64,9 @@ fn infer_lit_fails() {
 #[rstest::rstest]
 #[case(IntWidth::U0, 1)] // u0 max is 0
 #[case(IntWidth::U1, 2)] // u1 max is 1
-#[case(IntWidth::U8, 256)] // u8 max is 255
-#[case(IntWidth::U16, 65536)] // u16 max is 65535
-#[case(IntWidth::U32, 4294967296)] // u32 max is 4294967295
+#[case(IntWidth::U8, u64::from(u8::MAX) + 1)]
+#[case(IntWidth::U16, u64::from(u16::MAX) + 1)]
+#[case(IntWidth::U32, u64::from(u32::MAX) + 1)]
 fn check_lit_exceeds_max_fails(#[case] width: IntWidth, #[case] value: u64) {
     let src_arena = bumpalo::Bump::new();
     let core_arena = bumpalo::Bump::new();
@@ -81,10 +81,10 @@ fn check_lit_exceeds_max_fails(#[case] width: IntWidth, #[case] value: u64) {
 #[rstest::rstest]
 #[case(IntWidth::U0, 0)]
 #[case(IntWidth::U1, 1)]
-#[case(IntWidth::U8, 255)]
-#[case(IntWidth::U16, 65535)]
-#[case(IntWidth::U32, 4294967295)]
-#[case(IntWidth::U64, 18446744073709551615)]
+#[case(IntWidth::U8, u64::from(u8::MAX))]
+#[case(IntWidth::U16, u64::from(u16::MAX))]
+#[case(IntWidth::U32, u64::from(u32::MAX))]
+#[case(IntWidth::U64, u64::MAX)]
 fn check_lit_at_max_succeeds(#[case] width: IntWidth, #[case] value: u64) {
     let src_arena = bumpalo::Bump::new();
     let core_arena = bumpalo::Bump::new();

--- a/compiler/src/checker/test/mod.rs
+++ b/compiler/src/checker/test/mod.rs
@@ -1,7 +1,8 @@
 #![allow(
     clippy::get_first,
     clippy::wildcard_enum_match_arm,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::similar_names
 )]
 
 use std::collections::HashMap;

--- a/compiler/src/core/value.rs
+++ b/compiler/src/core/value.rs
@@ -139,7 +139,7 @@ pub fn eval<'a>(arena: &'a Bump, env: &[Value<'a>], term: &'a Term<'a>) -> Value
                     Pat::Lit(m) if n == *m => {
                         return eval(arena, env, arm.body);
                     }
-                    Pat::Lit(_) => continue,
+                    Pat::Lit(_) => {}
                     Pat::Bind(_) | Pat::Wildcard => {
                         let mut env2 = env.to_vec();
                         // TODO(#24): Type should come from scrutinee, not hardcoded u64

--- a/compiler/src/lexer/test/mod.rs
+++ b/compiler/src/lexer/test/mod.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::use_debug)]
+
 pub mod fuzz;

--- a/compiler/src/parser/test/mod.rs
+++ b/compiler/src/parser/test/mod.rs
@@ -2,7 +2,7 @@
     clippy::get_first,
     clippy::indexing_slicing,
     clippy::use_debug,
-    clippy::wildcard_enum_match_arm,
+    clippy::wildcard_enum_match_arm
 )]
 
 use std::path::PathBuf;

--- a/compiler/src/parser/test/mod.rs
+++ b/compiler/src/parser/test/mod.rs
@@ -1,7 +1,8 @@
 #![allow(
     clippy::get_first,
+    clippy::indexing_slicing,
+    clippy::use_debug,
     clippy::wildcard_enum_match_arm,
-    clippy::indexing_slicing
 )]
 
 use std::path::PathBuf;

--- a/compiler/src/staging/mod.rs
+++ b/compiler/src/staging/mod.rs
@@ -254,6 +254,7 @@ fn apply_closure_n<'out, 'eval>(
 }
 
 /// Evaluate a primitive operation at meta level.
+#[expect(clippy::too_many_lines)]
 fn eval_meta_prim<'out, 'eval>(
     arena: &'out Bump,
     eval_arena: &'eval Bump,

--- a/compiler/tests/snap.rs
+++ b/compiler/tests/snap.rs
@@ -24,10 +24,13 @@ fn snap(#[files("tests/snap/*/*/0_input.splic")] path: PathBuf) {
     // ── Phase 1: Lex ────────────────────────────────────────────────────────
     let lex_result: Result<Vec<_>, _> = Lexer::new(&input).collect();
     let lex_snap = match &lex_result {
-        Ok(tokens) => tokens
-            .iter()
-            .map(|t| format!("{t:?}\n"))
-            .collect::<String>(),
+        Ok(tokens) => {
+            use std::fmt::Write as _;
+            tokens.iter().fold(String::new(), |mut s, t| {
+                writeln!(s, "{t:?}").unwrap();
+                s
+            })
+        }
         Err(e) => format!("ERROR\n{e:#}\n"),
     };
     expect_file![dir.join("1_lex.txt")].assert_eq(&lex_snap);


### PR DESCRIPTION
Enable `pedantic` lint group. For each violation:
- Fix `similar_names`: inline `core_args` in infer.rs; allow in checker test module
- Fix `unreadable_literal`: use `u64::from(u8::MAX)` etc. instead of magic numbers
- Fix `needless_continue`: replace with `{}`
- Fix `items_after_statements`: move `use ast::BinOp` to top of block
- Fix `cast_lossless`: use `u64::from(...)` instead of `as u64`
- Fix `format_collect`: use `fold` + `write!` in snap.rs
- Allow `single_match_else` globally (match is clearer in context)
- Allow `must_use_candidate`, `missing_panics_doc`, `missing_errors_doc` globally
- Suppress `too_many_lines` with `#[expect]` on `infer`, `check_val_impl`, `eval_meta_prim`