### PR TITLE
refactor: introduce generic Env<T> and consolidate environment handlng

### DIFF
--- a/compiler/src/checker/ctx.rs
+++ b/compiler/src/checker/ctx.rs
@@ -117,14 +117,8 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
         &self,
         name: &core::Name,
     ) -> Option<(de_bruijn::Ix, &value::Value<'names, 'core>)> {
-        for (i, entry) in self.locals.iter().enumerate().rev() {
-            if entry.name == name {
-                let lvl = de_bruijn::Lvl::new(i);
-                let ix = lvl.ix_at(self.depth());
-                return Some((ix, &entry.ty));
-            }
-        }
-        None
+        let (_, ix, entry) = self.locals.lookup(name, |e| e.name)?;
+        Some((ix, &entry.ty))
     }
 
     /// Helper to create a lifted type [[T]]
@@ -138,7 +132,7 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
     /// Collect the values of all local bindings as an `Env<Value>` for use with `value::eval`.
     pub fn value_env(&self) -> value::Env<'names, 'core> {
         let mut env = value::Env::with_capacity(self.locals.depth().as_usize());
-        for entry in self.locals.iter() {
+        for entry in self.locals.iter_by_lvl() {
             env.push(entry.val.clone());
         }
         env

--- a/compiler/src/checker/ctx.rs
+++ b/compiler/src/checker/ctx.rs
@@ -1,7 +1,21 @@
 use std::collections::HashMap;
 
 use crate::common::de_bruijn;
+use crate::common::env::Env;
 use crate::core::{self, value};
+
+/// A single entry in the elaboration context.
+#[derive(Clone, Debug)]
+pub struct CtxEntry<'names, 'core> {
+    /// Variable name (for lookup and error messages).
+    pub name: &'names core::Name,
+    /// Type of the variable as a semantic value.
+    pub ty: value::Value<'names, 'core>,
+    /// Value of the variable in the evaluation environment.
+    /// For lambda/Pi parameters this is `Rigid(level)`; for `let` bindings it is
+    /// the evaluated expression.
+    pub val: value::Value<'names, 'core>,
+}
 
 /// Elaboration context.
 ///
@@ -16,16 +30,8 @@ pub struct Ctx<'names, 'core, 'globals> {
     /// Arena for allocating core terms
     pub arena: &'core bumpalo::Bump,
 
-    /// Local variable names (oldest first), for error messages.
-    pub names: Vec<&'names core::Name>,
-
-    /// Evaluation environment (oldest first): values of locals.
-    /// `env[env.len() - 1 - ix]` = value of `Var(Ix(ix))`.
-    pub env: value::Env<'names, 'core>,
-
-    /// Types of locals as semantic values (oldest first).
-    /// `types[types.len() - 1 - ix]` = type of `Var(Ix(ix))`.
-    pub types: Vec<value::Value<'names, 'core>>,
+    /// Local variable bindings (oldest first), each carrying name, type, and value.
+    pub locals: Env<CtxEntry<'names, 'core>>,
 
     /// Global function types: name -> Pi term.
     /// Storing `&Term` (always a Pi) unifies type lookup for globals and locals.
@@ -40,9 +46,7 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
     ) -> Self {
         Ctx {
             arena,
-            names: Vec::new(),
-            env: Vec::new(),
-            types: Vec::new(),
+            locals: Env::new(),
             globals,
         }
     }
@@ -60,15 +64,15 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
         self.arena.alloc_slice_fill_iter(items)
     }
 
-    /// Current De Bruijn depth — always equal to `env.len()`.
+    /// Current De Bruijn depth — always equal to the number of locals.
     pub const fn depth(&self) -> de_bruijn::Depth {
-        de_bruijn::Depth::new(self.env.len())
+        self.locals.depth()
     }
 
     /// Push a local variable onto the context, given its type as a term.
     /// Evaluates the type term in the current environment.
     pub fn push_local(&mut self, name: &'names core::Name, ty: &'core core::Term<'names, 'core>) {
-        let ty_val = value::eval(self.arena, &self.env, ty);
+        let ty_val = value::eval(self.arena, &self.value_env(), ty);
         self.push_local_val(name, ty_val);
     }
 
@@ -79,9 +83,12 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
         name: &'names core::Name,
         ty_val: value::Value<'names, 'core>,
     ) {
-        self.env.push(value::Value::Rigid(self.depth().as_lvl()));
-        self.types.push(ty_val);
-        self.names.push(name);
+        let lvl = self.depth().as_lvl();
+        self.locals.push(CtxEntry {
+            name,
+            ty: ty_val,
+            val: value::Value::Rigid(lvl),
+        });
     }
 
     /// Push a let binding: the variable has a known value in the environment.
@@ -92,16 +99,16 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
         ty_val: value::Value<'names, 'core>,
         expr_val: value::Value<'names, 'core>,
     ) {
-        self.env.push(expr_val);
-        self.types.push(ty_val);
-        self.names.push(name);
+        self.locals.push(CtxEntry {
+            name,
+            ty: ty_val,
+            val: expr_val,
+        });
     }
 
     /// Pop the last local variable
     pub fn pop_local(&mut self) {
-        self.names.pop();
-        self.env.pop();
-        self.types.pop();
+        self.locals.pop();
     }
 
     /// Look up a variable by name, returning its (index, type as Value).
@@ -110,14 +117,11 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
         &self,
         name: &core::Name,
     ) -> Option<(de_bruijn::Ix, &value::Value<'names, 'core>)> {
-        for (i, local_name) in self.names.iter().enumerate().rev() {
-            if *local_name == name {
-                let ix = de_bruijn::Lvl::new(i).ix_at(self.depth());
-                let ty = self
-                    .types
-                    .get(i)
-                    .expect("types and names are always the same length");
-                return Some((ix, ty));
+        for (i, entry) in self.locals.iter().enumerate().rev() {
+            if entry.name == name {
+                let lvl = de_bruijn::Lvl::new(i);
+                let ix = lvl.ix_at(self.depth());
+                return Some((ix, &entry.ty));
             }
         }
         None
@@ -131,9 +135,18 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
         self.arena.alloc(core::Term::Lift(inner))
     }
 
+    /// Collect the values of all local bindings as an `Env<Value>` for use with `value::eval`.
+    pub fn value_env(&self) -> value::Env<'names, 'core> {
+        let mut env = value::Env::with_capacity(self.locals.depth().as_usize());
+        for entry in self.locals.iter() {
+            env.push(entry.val.clone());
+        }
+        env
+    }
+
     /// Evaluate a term in the current environment.
     pub fn eval(&self, term: &'core core::Term<'names, 'core>) -> value::Value<'names, 'core> {
-        value::eval(self.arena, &self.env, term)
+        value::eval(self.arena, &self.value_env(), term)
     }
 
     /// Quote a value back to a term at the current depth.

--- a/compiler/src/checker/infer.rs
+++ b/compiler/src/checker/infer.rs
@@ -47,7 +47,7 @@ pub fn infer<'names, 'ast, 'core>(
             }
             // Globals — bare reference without call
             if let Some(pi) = ctx.globals.get(name).copied() {
-                let ty = value::eval_pi(ctx.arena, &[], pi);
+                let ty = value::eval_pi(ctx.arena, &value::Env::new(), pi);
                 return Ok((ctx.alloc(core::Term::Global(name)), ty));
             }
             Err(anyhow!("unbound variable `{name}`"))
@@ -731,10 +731,8 @@ fn check_val_impl<'names, 'ast, 'core>(
 
                     let arm_expected = match (&scrut_refine, &core_pat, expected_term) {
                         (Some((lvl, int_ty)), core::Pat::Lit(n), Some(ety)) => {
-                            let mut env = ctx.env.clone();
-                            *env.get_mut(lvl.as_usize())
-                                .expect("scrutinee level must be in scope") =
-                                value::Value::Lit(*n, *int_ty);
+                            let mut env = ctx.value_env();
+                            env[*lvl] = value::Value::Lit(*n, *int_ty);
                             value::eval(ctx.arena, &env, ety)
                         }
                         _ => expected.clone(),

--- a/compiler/src/common/de_bruijn.rs
+++ b/compiler/src/common/de_bruijn.rs
@@ -1,5 +1,5 @@
 /// De Bruijn level (counts from the outermost binder, 0 = outermost)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, derive_more::Display, PartialEq, Eq, Hash)]
 pub struct Lvl(usize);
 
 impl Lvl {
@@ -28,7 +28,7 @@ impl Lvl {
 }
 
 /// De Bruijn index (counts from nearest enclosing binder, 0 = innermost)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, derive_more::Display, PartialEq, Eq, Hash)]
 pub struct Ix(usize);
 
 impl Ix {
@@ -46,13 +46,14 @@ impl Ix {
         Self(self.0 + 1)
     }
 
+    /// Convert this index to the corresponding De Bruijn level given `depth`.
     #[must_use]
-    pub const fn lvl_at(self, depth: Depth) -> Self {
+    pub const fn lvl_at(self, depth: Depth) -> Lvl {
         let result = depth
             .0
             .checked_sub(self.0 + 1)
             .expect("De Bruijn index out of range for depth (index must be < depth)");
-        Self(result)
+        Lvl(result)
     }
 }
 
@@ -60,7 +61,7 @@ impl Ix {
 ///
 /// Same as `Lvl` but used to count how many binders down the current expression is,
 /// not to index into environment.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, derive_more::Display, PartialEq, Eq, Hash)]
 pub struct Depth(usize);
 
 impl Depth {

--- a/compiler/src/common/env.rs
+++ b/compiler/src/common/env.rs
@@ -1,0 +1,125 @@
+use std::ops::{Index, IndexMut};
+
+use derive_more::Debug;
+
+use super::de_bruijn::{Depth, Lvl};
+
+/// A level-indexed environment: entries stored oldest-first.
+///
+/// `get(Lvl(i))` returns `entries[i]`.  `depth()` returns the number of
+/// entries as a [`Depth`].  All mutations go through typed accessors so
+/// callers never have to think about the oldest-first layout.
+#[derive(Clone, Debug, Default)]
+pub struct Env<T> {
+    entries: Vec<T>,
+}
+
+impl<T> Env<T> {
+    pub const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Number of entries, expressed as a De Bruijn depth.
+    pub const fn depth(&self) -> Depth {
+        Depth::new(self.entries.len())
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Append an entry; it becomes the new innermost binding.
+    pub fn push(&mut self, val: T) {
+        self.entries.push(val);
+    }
+
+    /// Remove and return the innermost entry.
+    ///
+    /// # Panics
+    /// Panics if the environment is empty.
+    pub fn pop(&mut self) -> T {
+        self.entries.pop().expect("pop on empty Env")
+    }
+
+    /// Retrieve the entry at De Bruijn level `lvl`.
+    ///
+    /// # Panics
+    /// Panics if `lvl` is out of bounds.
+    pub fn get(&self, lvl: Lvl) -> &T {
+        self.entries
+            .get(lvl.as_usize())
+            .expect("De Bruijn level out of environment bounds")
+    }
+
+    /// Mutable access to the entry at level `lvl`.
+    ///
+    /// # Panics
+    /// Panics if `lvl` is out of bounds.
+    pub fn get_mut(&mut self, lvl: Lvl) -> &mut T {
+        self.entries
+            .get_mut(lvl.as_usize())
+            .expect("De Bruijn level out of environment bounds")
+    }
+
+    /// Truncate to `depth` entries, removing all entries beyond that depth.
+    pub fn truncate(&mut self, depth: Depth) {
+        self.entries.truncate(depth.as_usize());
+    }
+
+    /// Extend with the entries produced by `iter`.
+    pub fn extend(&mut self, iter: impl IntoIterator<Item = T>) {
+        self.entries.extend(iter);
+    }
+
+    /// A slice view of all entries (oldest first).
+    pub fn as_slice(&self) -> &[T] {
+        &self.entries
+    }
+
+    /// Iterate over entries oldest-first.  Supports `.rev()` for innermost-first.
+    #[expect(
+        clippy::iter_without_into_iter,
+        reason = "IntoIterator not needed here"
+    )]
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.entries.iter()
+    }
+
+    #[expect(
+        clippy::iter_without_into_iter,
+        reason = "IntoIterator not needed here"
+    )]
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
+        self.entries.iter_mut()
+    }
+
+    /// Iterate over `(level, entry)` pairs.
+    pub fn iter_with_lvl(&self) -> impl Iterator<Item = (Lvl, &T)> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (Lvl::new(i), v))
+    }
+}
+
+impl<T> Index<Lvl> for Env<T> {
+    type Output = T;
+
+    fn index(&self, lvl: Lvl) -> &T {
+        self.get(lvl)
+    }
+}
+
+impl<T> IndexMut<Lvl> for Env<T> {
+    fn index_mut(&mut self, lvl: Lvl) -> &mut T {
+        self.get_mut(lvl)
+    }
+}

--- a/compiler/src/common/env.rs
+++ b/compiler/src/common/env.rs
@@ -2,13 +2,9 @@ use std::ops::{Index, IndexMut};
 
 use derive_more::Debug;
 
-use super::de_bruijn::{Depth, Lvl};
+use super::de_bruijn::{Depth, Ix, Lvl};
 
 /// A level-indexed environment: entries stored oldest-first.
-///
-/// `get(Lvl(i))` returns `entries[i]`.  `depth()` returns the number of
-/// entries as a [`Depth`].  All mutations go through typed accessors so
-/// callers never have to think about the oldest-first layout.
 #[derive(Clone, Debug, Default)]
 pub struct Env<T> {
     entries: Vec<T>,
@@ -42,31 +38,43 @@ impl<T> Env<T> {
     }
 
     /// Remove and return the innermost entry.
-    ///
-    /// # Panics
-    /// Panics if the environment is empty.
     pub fn pop(&mut self) -> T {
         self.entries.pop().expect("pop on empty Env")
     }
 
     /// Retrieve the entry at De Bruijn level `lvl`.
-    ///
-    /// # Panics
-    /// Panics if `lvl` is out of bounds.
-    pub fn get(&self, lvl: Lvl) -> &T {
+    pub fn get_at_lvl(&self, lvl: Lvl) -> &T {
         self.entries
             .get(lvl.as_usize())
             .expect("De Bruijn level out of environment bounds")
     }
 
     /// Mutable access to the entry at level `lvl`.
-    ///
-    /// # Panics
-    /// Panics if `lvl` is out of bounds.
-    pub fn get_mut(&mut self, lvl: Lvl) -> &mut T {
+    pub fn get_at_lvl_mut(&mut self, lvl: Lvl) -> &mut T {
         self.entries
             .get_mut(lvl.as_usize())
             .expect("De Bruijn level out of environment bounds")
+    }
+
+    /// Convert De Bruijn index to level.
+    pub const fn ix_to_lvl(&self, ix: Ix) -> Lvl {
+        ix.lvl_at(self.depth())
+    }
+
+    /// Convert De Bruijn level to index.
+    pub const fn lvl_to_ix(&self, lvl: Lvl) -> Ix {
+        lvl.ix_at(self.depth())
+    }
+
+    /// Retrieve the entry at De Bruijn index `ix`.
+    pub fn get_at_ix(&self, ix: Ix) -> &T {
+        self.get_at_lvl(self.ix_to_lvl(ix))
+    }
+
+    /// Mutable access to the entry at De Bruijn index `ix`.
+    pub fn get_at_ix_mut(&mut self, ix: Ix) -> &mut T {
+        let lvl = self.ix_to_lvl(ix);
+        self.get_at_lvl_mut(lvl)
     }
 
     /// Truncate to `depth` entries, removing all entries beyond that depth.
@@ -74,35 +82,39 @@ impl<T> Env<T> {
         self.entries.truncate(depth.as_usize());
     }
 
-    /// Extend with the entries produced by `iter`.
-    pub fn extend(&mut self, iter: impl IntoIterator<Item = T>) {
-        self.entries.extend(iter);
-    }
-
     /// A slice view of all entries (oldest first).
     pub fn as_slice(&self) -> &[T] {
         &self.entries
     }
 
-    /// Iterate over entries oldest-first.  Supports `.rev()` for innermost-first.
-    #[expect(
-        clippy::iter_without_into_iter,
-        reason = "IntoIterator not needed here"
-    )]
-    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+    /// Iterate over entries oldest-first (by De Bruijn level).  Supports `.rev()` for innermost-first.
+    pub fn iter_by_lvl(&self) -> std::slice::Iter<'_, T> {
         self.entries.iter()
     }
 
-    #[expect(
-        clippy::iter_without_into_iter,
-        reason = "IntoIterator not needed here"
-    )]
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
-        self.entries.iter_mut()
+    /// Search innermost-first; return `(lvl, ix, entry)` for the first match.
+    pub fn find_innermost<F: Fn(&T) -> bool>(&self, pred: F) -> Option<(Lvl, Ix, &T)> {
+        for (i, entry) in self.entries.iter().enumerate().rev() {
+            if pred(entry) {
+                let lvl = Lvl::new(i);
+                let ix = lvl.ix_at(self.depth());
+                return Some((lvl, ix, entry));
+            }
+        }
+        None
+    }
+
+    /// Look up the innermost entry whose name (extracted via `key`) equals `name`.
+    pub fn lookup<N, F>(&self, name: &N, key: F) -> Option<(Lvl, Ix, &T)>
+    where
+        N: PartialEq + ?Sized,
+        F: Fn(&T) -> &N,
+    {
+        self.find_innermost(|e| key(e) == name)
     }
 
     /// Iterate over `(level, entry)` pairs.
-    pub fn iter_with_lvl(&self) -> impl Iterator<Item = (Lvl, &T)> {
+    pub fn iter_with_lvl(&self) -> impl DoubleEndedIterator<Item = (Lvl, &T)> + ExactSizeIterator {
         self.entries
             .iter()
             .enumerate()
@@ -110,16 +122,44 @@ impl<T> Env<T> {
     }
 }
 
+impl<T> std::iter::Extend<T> for Env<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.entries.extend(iter);
+    }
+}
+
+impl<T> FromIterator<T> for Env<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self {
+            entries: Vec::from_iter(iter),
+        }
+    }
+}
+
 impl<T> Index<Lvl> for Env<T> {
     type Output = T;
 
     fn index(&self, lvl: Lvl) -> &T {
-        self.get(lvl)
+        self.get_at_lvl(lvl)
     }
 }
 
 impl<T> IndexMut<Lvl> for Env<T> {
     fn index_mut(&mut self, lvl: Lvl) -> &mut T {
-        self.get_mut(lvl)
+        self.get_at_lvl_mut(lvl)
+    }
+}
+
+impl<T> Index<Ix> for Env<T> {
+    type Output = T;
+
+    fn index(&self, ix: Ix) -> &T {
+        self.get_at_ix(ix)
+    }
+}
+
+impl<T> IndexMut<Ix> for Env<T> {
+    fn index_mut(&mut self, ix: Ix) -> &mut T {
+        self.get_at_ix_mut(ix)
     }
 }

--- a/compiler/src/common/mod.rs
+++ b/compiler/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod de_bruijn;
+pub mod env;
 pub mod name;
 pub mod operators;
 pub mod phase;

--- a/compiler/src/core/pretty.rs
+++ b/compiler/src/core/pretty.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::common::de_bruijn;
+use crate::common::env::Env;
 use crate::parser::ast::Phase;
 
 use super::{Arm, Function, Name, Pat, Program, Term};
@@ -19,7 +19,7 @@ impl<'names> Term<'names, '_> {
     /// (the caller is responsible for any surrounding braces).
     fn fmt_term(
         &self,
-        env: &mut Vec<&'names Name>,
+        env: &mut Env<&'names Name>,
         indent: usize,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
@@ -41,19 +41,16 @@ impl<'names> Term<'names, '_> {
     /// a new indented block (e.g. `Let` / `Match`).
     fn fmt_term_inline(
         &self,
-        env: &mut Vec<&'names Name>,
+        env: &mut Env<&'names Name>,
         indent: usize,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
         match self {
             // ── Variable ─────────────────────────────────────────────────────────
             Term::Var(ix) => {
-                let lvl = ix.lvl_at(de_bruijn::Depth::new(env.len()));
-                let i = lvl.as_usize();
-                let name = env
-                    .get(i)
-                    .expect("De Bruijn level out of environment bounds");
-                write!(f, "{name}@{i}")
+                let lvl = ix.lvl_at(env.depth());
+                let name = env.get(lvl);
+                write!(f, "{name}@{lvl}")
             }
 
             // ── Literal ──────────────────────────────────────────────────────────
@@ -80,7 +77,7 @@ impl<'names> Term<'names, '_> {
 
             // ── Pi type ───────────────────────────────────────────────────────────
             Term::Pi(pi) => {
-                let env_before = env.len();
+                let env_before = env.depth();
                 write!(f, "fn(")?;
                 for (i, &(name, ty)) in pi.params.iter().enumerate() {
                     if i > 0 {
@@ -89,7 +86,7 @@ impl<'names> Term<'names, '_> {
                     if name.as_str() == "_" {
                         write!(f, "_: ")?;
                     } else {
-                        write!(f, "{}@{}: ", name, env.len())?;
+                        write!(f, "{}@{}: ", name, env.depth())?;
                     }
                     ty.fmt_expr(env, indent, f)?;
                     env.push(name);
@@ -102,13 +99,13 @@ impl<'names> Term<'names, '_> {
 
             // ── Lambda ────────────────────────────────────────────────────────────
             Term::Lam(lam) => {
-                let env_before = env.len();
+                let env_before = env.depth();
                 write!(f, "|")?;
                 for (i, &(name, ty)) in lam.params.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}@{}: ", name, env.len())?;
+                    write!(f, "{}@{}: ", name, env.depth())?;
                     ty.fmt_expr(env, indent, f)?;
                     env.push(name);
                 }
@@ -139,7 +136,7 @@ impl<'names> Term<'names, '_> {
             // In statement position: print as a flat let-chain without extra braces.
             Term::Let(let_) => {
                 write_indent(f, indent)?;
-                write!(f, "let {}@{}: ", let_.name, env.len())?;
+                write!(f, "let {}@{}: ", let_.name, env.depth())?;
                 let_.ty.fmt_expr(env, indent, f)?;
                 write!(f, " = ")?;
                 let_.expr.fmt_expr(env, indent, f)?;
@@ -171,7 +168,7 @@ impl<'names> Term<'names, '_> {
     /// syntactically valid as sub-expressions.
     fn fmt_expr(
         &self,
-        env: &mut Vec<&'names Name>,
+        env: &mut Env<&'names Name>,
         indent: usize,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
@@ -201,7 +198,7 @@ impl<'names> Arm<'names, '_> {
     /// Print a single match arm.
     fn fmt_arm(
         &self,
-        env: &mut Vec<&'names Name>,
+        env: &mut Env<&'names Name>,
         indent: usize,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
@@ -210,8 +207,7 @@ impl<'names> Arm<'names, '_> {
             Pat::Lit(n) => write!(f, "{n} => ")?,
             Pat::Wildcard => write!(f, "_ => ")?,
             Pat::Bind(name) => {
-                let lvl = env.len();
-                write!(f, "{name}@{lvl} => ")?;
+                write!(f, "{name}@{} => ", env.depth())?;
                 env.push(*name);
                 self.body.fmt_expr(env, indent, f)?;
                 env.pop();
@@ -242,7 +238,7 @@ impl fmt::Display for Function<'_, '_> {
         let pi = self.pi();
 
         // Build the name environment for the body: one entry per parameter.
-        let mut env: Vec<&Name> = Vec::with_capacity(pi.params.len());
+        let mut env: Env<&Name> = Env::with_capacity(pi.params.len());
 
         // Phase prefix.
         match pi.phase {

--- a/compiler/src/core/pretty.rs
+++ b/compiler/src/core/pretty.rs
@@ -48,7 +48,7 @@ impl<'names> Term<'names, '_> {
         match self {
             // ── Variable ─────────────────────────────────────────────────────────
             Term::Var(ix) => {
-                let name = env.get_at_ix(*ix);
+                let name = &env[*ix];
                 let lvl = env.ix_to_lvl(*ix);
                 write!(f, "{name}@{lvl}")
             }

--- a/compiler/src/core/pretty.rs
+++ b/compiler/src/core/pretty.rs
@@ -48,8 +48,8 @@ impl<'names> Term<'names, '_> {
         match self {
             // ── Variable ─────────────────────────────────────────────────────────
             Term::Var(ix) => {
-                let lvl = ix.lvl_at(env.depth());
-                let name = env.get(lvl);
+                let name = env.get_at_ix(*ix);
+                let lvl = env.ix_to_lvl(*ix);
                 write!(f, "{name}@{lvl}")
             }
 
@@ -77,7 +77,7 @@ impl<'names> Term<'names, '_> {
 
             // ── Pi type ───────────────────────────────────────────────────────────
             Term::Pi(pi) => {
-                let env_before = env.depth();
+                let depth_before = env.depth();
                 write!(f, "fn(")?;
                 for (i, &(name, ty)) in pi.params.iter().enumerate() {
                     if i > 0 {
@@ -93,13 +93,13 @@ impl<'names> Term<'names, '_> {
                 }
                 write!(f, ") -> ")?;
                 pi.body_ty.fmt_expr(env, indent, f)?;
-                env.truncate(env_before);
+                env.truncate(depth_before);
                 Ok(())
             }
 
             // ── Lambda ────────────────────────────────────────────────────────────
             Term::Lam(lam) => {
-                let env_before = env.depth();
+                let depth_before = env.depth();
                 write!(f, "|")?;
                 for (i, &(name, ty)) in lam.params.iter().enumerate() {
                     if i > 0 {
@@ -111,7 +111,7 @@ impl<'names> Term<'names, '_> {
                 }
                 write!(f, "| ")?;
                 lam.body.fmt_expr(env, indent, f)?;
-                env.truncate(env_before);
+                env.truncate(depth_before);
                 Ok(())
             }
 

--- a/compiler/src/core/value.rs
+++ b/compiler/src/core/value.rs
@@ -73,14 +73,14 @@ pub struct Closure<'names, 'a> {
 
 /// Evaluate a term in an environment, producing a semantic value.
 ///
-/// `env.get(lvl)` gives the value for the variable at De Bruijn level `lvl`.
+/// `env.get_at_lvl(lvl)` gives the value for the variable at De Bruijn level `lvl`.
 pub fn eval<'names, 'a>(
     arena: &'a Bump,
     env: &Env<'names, 'a>,
     term: &'a Term<'names, 'a>,
 ) -> Value<'names, 'a> {
     match term {
-        Term::Var(ix) => env.get(ix.lvl_at(env.depth())).clone(),
+        Term::Var(ix) => env.get_at_ix(*ix).clone(),
 
         Term::Prim(p) => Value::Prim(*p),
         Term::Lit(n, it) => Value::Lit(*n, *it),
@@ -169,7 +169,7 @@ pub fn eval_pi<'names, 'a>(
     env: &Env<'names, 'a>,
     pi: &'a Pi<'names, 'a>,
 ) -> Value<'names, 'a> {
-    let env_snapshot = arena.alloc_slice_fill_iter(env.iter().cloned());
+    let env_snapshot = arena.alloc_slice_fill_iter(env.iter_by_lvl().cloned());
     let params: Vec<(&'names Name, Closure<'names, 'a>)> = pi
         .params
         .iter()
@@ -199,7 +199,7 @@ fn eval_lam<'names, 'a>(
     env: &Env<'names, 'a>,
     lam: &'a Lam<'names, 'a>,
 ) -> Value<'names, 'a> {
-    let env_snapshot = arena.alloc_slice_fill_iter(env.iter().cloned());
+    let env_snapshot = arena.alloc_slice_fill_iter(env.iter_by_lvl().cloned());
     let params: Vec<(&'names Name, Closure<'names, 'a>)> = lam
         .params
         .iter()
@@ -265,9 +265,12 @@ pub fn inst_n<'names, 'a>(
     closure: &Closure<'names, 'a>,
     args: &[Value<'names, 'a>],
 ) -> Value<'names, 'a> {
-    let mut env = Env::new();
-    env.extend(closure.env.iter().cloned());
-    env.extend(args.iter().cloned());
+    let env: Env<'names, 'a> = closure
+        .env
+        .iter()
+        .cloned()
+        .chain(args.iter().cloned())
+        .collect();
     eval(arena, &env, closure.body)
 }
 

--- a/compiler/src/core/value.rs
+++ b/compiler/src/core/value.rs
@@ -265,12 +265,8 @@ pub fn inst_n<'names, 'a>(
     closure: &Closure<'names, 'a>,
     args: &[Value<'names, 'a>],
 ) -> Value<'names, 'a> {
-    let env: Env<'names, 'a> = closure
-        .env
-        .iter()
-        .cloned()
-        .chain(args.iter().cloned())
-        .collect();
+    let clos_env = closure.env.iter().cloned();
+    let env: Env<'names, 'a> = clos_env.chain(args.iter().cloned()).collect();
     eval(arena, &env, closure.body)
 }
 

--- a/compiler/src/core/value.rs
+++ b/compiler/src/core/value.rs
@@ -10,9 +10,9 @@ use super::prim::IntType;
 use super::{Lam, Name, Pat, Pi, Prim, Term};
 use crate::common::{Phase, de_bruijn};
 
-/// Working evaluation environment: index 0 = outermost binding, last = innermost.
+/// Working evaluation environment: index 0 = outermost binding (level 0), last = innermost.
 /// `Var(Ix(i))` maps to `env[env.len() - 1 - i]`.
-pub type Env<'names, 'a> = Vec<Value<'names, 'a>>;
+pub type Env<'names, 'a> = crate::common::env::Env<Value<'names, 'a>>;
 
 /// Semantic value — result of evaluating a term or type.
 #[derive(Clone, Debug)]
@@ -73,20 +73,14 @@ pub struct Closure<'names, 'a> {
 
 /// Evaluate a term in an environment, producing a semantic value.
 ///
-/// `env[env.len() - 1 - ix]` gives the value for `Var(Ix(ix))`.
+/// `env.get(lvl)` gives the value for the variable at De Bruijn level `lvl`.
 pub fn eval<'names, 'a>(
     arena: &'a Bump,
-    env: &[Value<'names, 'a>],
+    env: &Env<'names, 'a>,
     term: &'a Term<'names, 'a>,
 ) -> Value<'names, 'a> {
     match term {
-        Term::Var(ix) => {
-            let lvl = ix.lvl_at(de_bruijn::Depth::new(env.len()));
-            let i = lvl.as_usize();
-            env.get(i)
-                .expect("De Bruijn index out of environment bounds")
-                .clone()
-        }
+        Term::Var(ix) => env.get(ix.lvl_at(env.depth())).clone(),
 
         Term::Prim(p) => Value::Prim(*p),
         Term::Lit(n, it) => Value::Lit(*n, *it),
@@ -125,7 +119,7 @@ pub fn eval<'names, 'a>(
 
         Term::Let(let_) => {
             let val = eval(arena, env, let_.expr);
-            let mut env2: Vec<Value<'names, 'a>> = env.to_vec();
+            let mut env2 = env.clone();
             env2.push(val);
             eval(arena, &env2, let_.body)
         }
@@ -146,7 +140,7 @@ pub fn eval<'names, 'a>(
                     }
                     Pat::Lit(_) => {}
                     Pat::Bind(_) | Pat::Wildcard => {
-                        let mut env2 = env.to_vec();
+                        let mut env2 = env.clone();
                         // TODO(#24): Type should come from scrutinee, not hardcoded u64
                         env2.push(Value::Lit(
                             n,
@@ -172,7 +166,7 @@ pub fn eval<'names, 'a>(
 /// parameters, so they are correctly differentiated despite sharing the base env.
 pub fn eval_pi<'names, 'a>(
     arena: &'a Bump,
-    env: &[Value<'names, 'a>],
+    env: &Env<'names, 'a>,
     pi: &'a Pi<'names, 'a>,
 ) -> Value<'names, 'a> {
     let env_snapshot = arena.alloc_slice_fill_iter(env.iter().cloned());
@@ -202,7 +196,7 @@ pub fn eval_pi<'names, 'a>(
 /// Evaluate a multi-param Lam into a multi-param `Value::Lam` (no currying).
 fn eval_lam<'names, 'a>(
     arena: &'a Bump,
-    env: &[Value<'names, 'a>],
+    env: &Env<'names, 'a>,
     lam: &'a Lam<'names, 'a>,
 ) -> Value<'names, 'a> {
     let env_snapshot = arena.alloc_slice_fill_iter(env.iter().cloned());
@@ -271,8 +265,9 @@ pub fn inst_n<'names, 'a>(
     closure: &Closure<'names, 'a>,
     args: &[Value<'names, 'a>],
 ) -> Value<'names, 'a> {
-    let mut env = closure.env.to_vec();
-    env.extend_from_slice(args);
+    let mut env = Env::new();
+    env.extend(closure.env.iter().cloned());
+    env.extend(args.iter().cloned());
     eval(arena, &env, closure.body)
 }
 
@@ -376,7 +371,7 @@ pub fn val_eq<'names, 'a>(
 
 /// Evaluate a term in the empty environment.
 pub fn eval_closed<'names, 'a>(arena: &'a Bump, term: &'a Term<'names, 'a>) -> Value<'names, 'a> {
-    eval(arena, &[], term)
+    eval(arena, &Env::new(), term)
 }
 
 /// Extract the Phase from a Value that represents a universe (Type or `VmType`),

--- a/compiler/src/core/value.rs
+++ b/compiler/src/core/value.rs
@@ -73,14 +73,14 @@ pub struct Closure<'names, 'a> {
 
 /// Evaluate a term in an environment, producing a semantic value.
 ///
-/// `env.get_at_lvl(lvl)` gives the value for the variable at De Bruijn level `lvl`.
+/// `env[lvl]` gives the value for the variable at De Bruijn level `lvl`.
 pub fn eval<'names, 'a>(
     arena: &'a Bump,
     env: &Env<'names, 'a>,
     term: &'a Term<'names, 'a>,
 ) -> Value<'names, 'a> {
     match term {
-        Term::Var(ix) => env.get_at_ix(*ix).clone(),
+        Term::Var(ix) => env[*ix].clone(),
 
         Term::Prim(p) => Value::Prim(*p),
         Term::Lit(n, it) => Value::Lit(*n, *it),

--- a/compiler/src/staging/mod.rs
+++ b/compiler/src/staging/mod.rs
@@ -114,8 +114,7 @@ impl<'names, 'eval> Env<'names, 'eval> {
 
     /// Look up the binding for `Var(Ix(ix))`.
     fn get_ix(&self, ix: de_bruijn::Ix) -> &Binding<'names, 'eval> {
-        let lvl = ix.lvl_at(self.bindings.depth());
-        self.bindings.get(lvl)
+        self.bindings.get_at_ix(ix)
     }
 
     /// Push an object-level binding.

--- a/compiler/src/staging/mod.rs
+++ b/compiler/src/staging/mod.rs
@@ -114,7 +114,7 @@ impl<'names, 'eval> Env<'names, 'eval> {
 
     /// Look up the binding for `Var(Ix(ix))`.
     fn get_ix(&self, ix: de_bruijn::Ix) -> &Binding<'names, 'eval> {
-        self.bindings.get_at_ix(ix)
+        &self.bindings[ix]
     }
 
     /// Push an object-level binding.

--- a/compiler/src/staging/mod.rs
+++ b/compiler/src/staging/mod.rs
@@ -4,6 +4,7 @@ use anyhow::{Result, anyhow, ensure};
 use bumpalo::Bump;
 
 use crate::common::de_bruijn;
+use crate::common::env::Env as LevelEnv;
 use crate::core::{Arm, Function, IntType, IntWidth, Name, Pat, Pi, Prim, Program, Term};
 use crate::parser::ast::Phase;
 
@@ -77,7 +78,7 @@ enum MetaVal<'names, 'eval> {
     Closure {
         body: &'eval Term<'names, 'eval>,
         arity: usize,
-        env: Vec<Binding<'names, 'eval>>,
+        env: LevelEnv<Binding<'names, 'eval>>,
         obj_depth: de_bruijn::Depth,
     },
 }
@@ -99,26 +100,22 @@ enum Binding<'names, 'eval> {
 /// `bindings[bindings.len() - 1 - i]` — the `i`-th binding from the end.
 #[derive(Debug)]
 struct Env<'names, 'eval> {
-    bindings: Vec<Binding<'names, 'eval>>,
+    bindings: LevelEnv<Binding<'names, 'eval>>,
     obj_depth: de_bruijn::Depth,
 }
 
 impl<'names, 'eval> Env<'names, 'eval> {
     const fn new(obj_depth: de_bruijn::Depth) -> Self {
         Env {
-            bindings: Vec::new(),
+            bindings: LevelEnv::new(),
             obj_depth,
         }
     }
 
     /// Look up the binding for `Var(Ix(ix))`.
     fn get_ix(&self, ix: de_bruijn::Ix) -> &Binding<'names, 'eval> {
-        let depth = de_bruijn::Depth::new(self.bindings.len());
-        let lvl = ix.lvl_at(depth);
-        let i = lvl.as_usize();
-        self.bindings
-            .get(i)
-            .expect("De Bruijn index out of environment bounds")
+        let lvl = ix.lvl_at(self.bindings.depth());
+        self.bindings.get(lvl)
     }
 
     /// Push an object-level binding.
@@ -135,7 +132,7 @@ impl<'names, 'eval> Env<'names, 'eval> {
 
     /// Pop the last binding.
     fn pop(&mut self) {
-        match self.bindings.pop().expect("pop on empty environment") {
+        match self.bindings.pop() {
             Binding::Obj(_) => {
                 self.obj_depth = self.obj_depth.pred();
             }
@@ -249,7 +246,7 @@ const fn global_to_closure<'names, 'eval>(
     MetaVal::Closure {
         body: def.body,
         arity: def.ty.params.len(),
-        env: Vec::new(),
+        env: LevelEnv::new(),
         obj_depth,
     }
 }


### PR DESCRIPTION
Add `common::env::Env<T>`, a level-indexed environment backed by a Vec with typed `depth()`/`push`/`pop`/`truncate`/`get(Lvl)` accessors.

Port all four environment sites to use it:
- `core/pretty.rs`: `Vec<&Name>` → `Env<&Name>`
- `core/value.rs`: `Vec<Value>` type alias → `Env<Value>`; `eval`, `eval_pi`, `eval_lam` now take `&Env` instead of `&[Value]`
- `checker/ctx.rs`: three parallel vecs (`names`, `env`, `types`) → single `Env<CtxEntry>` with a `value_env()` helper
- `staging/mod.rs`: inner `Vec<Binding>` → `LevelEnv<Binding>`

Also fix `Ix::lvl_at` to return `Lvl` instead of `Self`, and add `Display` to `Lvl`, `Ix`, and `Depth` via `derive_more`.

* closes #31