### PR TITLE
ai: improve agent scaffolding — feature gating docs, skill enhancements

### DIFF
--- a/.opencode/skills/address-review/SKILL.md
+++ b/.opencode/skills/address-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: address-review
-description: Download unresolved GitHub PR review comments and create a structured plan for addressing them. Use when the user wants to work through PR feedback.
-allowed-tools: Bash(.opencode/skills/address-review/fetch_comments.py), Bash(gh pr view *), Bash(gh repo view *)
+description: Download unresolved GitHub PR review comments and create a plan (in plan mode) or a todo list (otherwise) for addressing them. Use when the user wants to work through PR feedback.
+allowed-tools: Bash(.opencode/skills/address-review/fetch_comments.py), Bash(gh pr view *), Bash(gh repo view *), TaskCreate
 ---
 
 ## Unresolved Review Comments
@@ -36,9 +36,9 @@ Use read-only exploration (Glob, Grep, Read, Bash for `git log`/`gh`) to identif
 
 Do **not** do deep implementation research at this stage — just enough to point accurately to the right location.
 
-### Step 3 — Write the plan
+### Step 3 — Record the tasks
 
-Write the final plan to the plan file. Structure:
+**If you are in plan mode**, write a structured plan file. Structure:
 
 - **Context section** at the top: what this PR does and why these comments need addressing
 - One **section per task**, titled clearly (e.g. `T1 — Regression: empty lambda params`)
@@ -49,6 +49,8 @@ Write the final plan to the plan file. Structure:
   - **Complete context and constraints** from the comment(s): exact error messages, code examples, suggestions, workarounds mentioned, why the change matters
 - A **suggested implementation order** (regressions and bugs first, then cleanup, then docs, then issues to file)
 - A **verification section** with the exact commands to run after implementation
+
+**If you are not in plan mode**, create a todo list using TaskCreate instead. One task per item from Step 1, in implementation order (regressions first, then cleanup, then docs, then issues to file). Each task title should be self-contained (include the comment ID and a short description of the change).
 
 ### Guidelines
 

--- a/.opencode/skills/wrapup/SKILL.md
+++ b/.opencode/skills/wrapup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wrapup
-description: Reflect on task completion and record lessons learned. Use when the user says "wrapup", "wrap up", "wrap it up", "close out", or "record lessons learned". Distills what went well, what was tricky, and updates project knowledge to improve future sessions.
+description: Reflect on task completion and record lessons learned. Use when the user says "wrapup", "wrap up", "wrap it up", "close out", or "record lessons learned". Distills what went well, what was tricky, updates project knowledge, suggests GitHub issues for follow-up tasks, and logs technical debt.
 ---
 
 # Wrapup
@@ -31,7 +31,21 @@ Skip:
 - One-off debugging steps unlikely to recur
 - Implementation details that live in the code itself
 
-### Step 3 — Choose the right destination
+### Step 3 — Identify follow-up work
+
+Look for:
+- **Unfinished threads**: things explicitly deferred, stubbed out (`todo!()`, `// TODO`, placeholder implementations), or noted as "future work"
+- **Technical debt**: corners cut to keep scope manageable, workarounds for known limitations, or designs that will need revisiting as the project grows
+- **Open questions**: design decisions that weren't resolved, or areas where the right approach was uncertain
+
+For each item, decide:
+- **Propose a GitHub issue** if it's concrete enough to act on later and worth tracking publicly
+- **Note in a doc** (`docs/bs/`) if it's a design question or architectural trade-off worth preserving context for
+- Skip if it's too vague or already tracked elsewhere
+
+When proposing issues: draft a focused title and a short body with enough context that someone picking it up cold can understand the problem and the constraints. Present the draft to the user for review before running `gh issue create` — issue creation is public and requires explicit approval.
+
+### Step 4 — Choose the right destination for lessons
 
 | What | Where |
 |------|-------|
@@ -41,14 +55,15 @@ Skip:
 | User preferences, collaboration style | Auto-memory (`~/.claude/projects/.../memory/`) |
 | Corrected behavior for future Claude sessions | Auto-memory feedback entries |
 
-### Step 4 — Write the updates
+### Step 5 — Write the updates
 
 - **CLAUDE.md**: Add a bullet or short paragraph. Keep the file small and scannable. No restating what's obvious from the code.
 - **docs/**: Focus on "what" and "why" at a conceptual level. Avoid function names, parameter lists, exact APIs — these go stale. Brief "how" is fine if it illuminates the design.
 - **Skills**: Tighten trigger descriptions, add guidance about edge cases, or clarify scope.
 - **Memory**: Add feedback entries for behavioral corrections (see auto-memory guidelines).
+- **GitHub issues**: File for any concrete follow-up tasks identified in Step 3.
 
-### Step 5 — Optionally, refine this skill
+### Step 6 — Optionally, refine this skill
 
 If the wrapup process itself revealed a gap (e.g. a destination type is missing, guidance is ambiguous), improve this `SKILL.md` before finishing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ cargo bolero test           # Run bolero fuzz tests
 - Uses **rstest** for parameterized tests
 - Snapshot testing with **expect-test** (diff output may show ANSI color codes which can be misleading - if colors appear in the diff, run `UPDATE_EXPECT=1 cargo test` to regenerate snapshots and verify actual state)
 - Fuzz tests with **bolero** in component `test` modules
-- Note: When adding new `.input.txt` test files, run `cargo clean -p splic-compiler` first to ensure they're picked up by the test framework
+- Note: When adding new test input files, run `cargo clean -p <crate>` for the crate that owns the tests (e.g. `splic-driver` for integration tests, `splic-compiler` for unit tests) to ensure rstest picks them up
 
 ### Clippy
 The project enforces a curated set of lints beyond Clippy defaults — see `[workspace.lints]` in `Cargo.toml` for the full list. All lints are `"deny"`. Use `#[expect(...)]` to suppress a lint at a specific site. For test modules it is acceptable to use a broad `#![expect(...)]` at the top of the file rather than per-site annotations.
@@ -101,6 +101,10 @@ The project enforces a curated set of lints beyond Clippy defaults — see `[wor
 - For arena-allocated structures, refer to other objects using plain references rather than `Box`
 - In NbE (semantic evaluation), use slices `&'a [Value<'a>]` for environment snapshots captured in closures, not vectors
 - Prefer a local `Bump::new()` over accepting an arena parameter when all allocations are scratch temporaries that do not escape the function (e.g. intermediate structures used only for a comparison that returns a non-arena type)
+
+### Feature Gating
+- Use `cfg_if::cfg_if!` for if/else feature dispatch (not paired `#[cfg]` / `#[cfg(not(...))]` attributes)
+- Concentrate feature checks in a dedicated helper function; avoid `#[cfg]` on enum variants or match arms — the scattered approach triggers cascading lint failures (`used_underscore_binding`, `needless_pass_by_value`, `unused_variables`)
 
 ### Trait Implementations
 - Use `derive_more` for standard trait derives (`Display`, `Debug`, `From`, `AsRef`, `IsVariant`, etc.) instead of manual `impl` blocks


### PR DESCRIPTION
## Summary

- Documents the `cfg_if` + helper-function feature-gating convention in `AGENTS.md` (learned from PR #50 review)
- Generalizes the `cargo clean` test tip to any crate, not just `splic-compiler`
- Enhances `address-review` skill to create a todo list when not in plan mode
- Enhances `wrapup` skill to identify follow-up GitHub issues and log technical debt

## Test plan

- [ ] Verify `AGENTS.md` reads cleanly and additions are accurate
- [ ] Invoke `/address-review` outside plan mode and confirm TaskCreate is used
- [ ] Invoke `/wrapup` and confirm it surfaces follow-up issues and debt items

🤖 Generated with [Claude Code](https://claude.com/claude-code)