### PR TITLE
docs: fix broken intra-doc links and add rustdoc CI check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Clippy
         run: just clippy
 
+  doc:
+    name: Rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - uses: Swatinem/rust-cache@v2
+      - name: Check rustdocs
+        run: just check-doc
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/compiler/src/checker/ctx.rs
+++ b/compiler/src/checker/ctx.rs
@@ -121,7 +121,7 @@ impl<'names, 'core, 'globals> Ctx<'names, 'core, 'globals> {
         Some((ix, &entry.ty))
     }
 
-    /// Helper to create a lifted type [[T]]
+    /// Helper to create a lifted type \[\[T\]\]
     pub fn lift_ty(
         &self,
         inner: &'core core::Term<'names, 'core>,

--- a/compiler/src/core/mod.rs
+++ b/compiler/src/core/mod.rs
@@ -125,7 +125,7 @@ pub enum Term<'names, 'a> {
     /// Lambda abstraction: |x: A| body
     #[from]
     Lam(Lam<'names, 'a>),
-    /// Lift: [[T]] — meta type representing object-level code of type T
+    /// Lift: \[\[T\]\] — meta type representing object-level code of type T
     Lift(&'a Self),
     /// Quotation: #(t) — produce object-level code from a meta expression
     Quote(&'a Self),

--- a/docs/bs/prototype_eval.md
+++ b/docs/bs/prototype_eval.md
@@ -95,7 +95,6 @@ This approach was chosen over the substitution-first → spine-based path origin
 - It handles all three concerns (staging evaluator, type checker, definitional equality) with a single uniform mechanism.
 - The multi-param variadic design (see `pi_types.md`) fits naturally: domain closures for each parameter share a base environment snapshot and accumulate argument values incrementally.
 
-**Spine-based evaluation** remains an option for future optimization (lazy forcing under binders, more efficient unification), but is not currently required.
 
 ---
 
@@ -150,7 +149,7 @@ The original plan described three phases. The actual path differed: Phase 2 (spi
    - Dependent telescopes via domain closures.
    - See `pi_types.md` for the design.
 
-**Remaining future work**: spine-based evaluation (optimization), implicit arguments, object-level closures. See `prototype_next.md`.
+**Remaining future work**: implicit arguments, object-level closures. See `prototype_next.md`.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -57,5 +57,9 @@ doc-full:
 doc-md-full: _require-doc-md
     cargo doc-md --workspace --include-private
 
+# Check rustdocs for broken links and warnings (used in CI).
+check-doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --all-features --document-private-items
+
 # Run all CI checks.
-ci: check-fmt clippy test
+ci: check-fmt clippy check-doc test


### PR DESCRIPTION
Escape [[T]] brackets in two doc comments that rustdoc was interpreting as unresolved intra-doc links. Add a `check-doc` just recipe and corresponding CI job to catch regressions.