### PR TITLE
ci: test improvements, dependabot, update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
 
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      cargo:
+        patterns: ["*"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,8 +14,10 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@just
+      - uses: actions/checkout@v6.0.2
+      - uses: taiki-e/install-action@v2.75.15
+        with:
+          tool: just
       - name: Check formatting
         run: just check-fmt
 
@@ -23,9 +25,11 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@just
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: taiki-e/install-action@v2.75.15
+        with:
+          tool: just
+      - uses: Swatinem/rust-cache@v2.9.1
       - name: Clippy
         run: just clippy
 
@@ -33,9 +37,11 @@ jobs:
     name: Rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@just
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: taiki-e/install-action@v2.75.15
+        with:
+          tool: just
+      - uses: Swatinem/rust-cache@v2.9.1
       - name: Check rustdocs
         run: just check-doc
 
@@ -43,8 +49,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@just
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: taiki-e/install-action@v2.75.15
+        with:
+          tool: just
+      - uses: Swatinem/rust-cache@v2.9.1
       - name: Run tests
         run: just test-full

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - uses: taiki-e/install-action@just
       - name: Check formatting
         run: just check-fmt
@@ -23,7 +23,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
       - name: Clippy
@@ -33,7 +33,7 @@ jobs:
     name: Rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
       - name: Check rustdocs
@@ -43,7 +43,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
       - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6
       - uses: taiki-e/install-action@just
       - name: Check formatting
         run: just check-fmt
@@ -23,7 +23,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
       - name: Clippy
@@ -33,7 +33,7 @@ jobs:
     name: Rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
       - name: Check rustdocs
@@ -43,7 +43,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
       - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,7 @@ dependencies = [
  "rstest",
  "splic-backend-wasm",
  "splic-compiler",
+ "splic-driver",
  "wasmprinter",
 ]
 

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -18,6 +18,7 @@ anyhow.workspace = true
 bumpalo.workspace = true
 
 [dev-dependencies]
+splic-driver = { path = ".", features = ["backend-wasm"] }
 expect-test = "1.5"
 rstest = "0.26"
 wasmprinter = { version = "0.246", default-features = false }


### PR DESCRIPTION
Ensures cargo test -p splic-driver activates the wasm backend, so 8_wasm.wat snapshots are exercised without needing --workspace.