### PR TITLE
chore: split justfile into modules for fuzz, doc, and sanitizers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           tool: just
       - name: Check formatting
-        run: just check-fmt
+        run: just ci::check-fmt
 
   clippy:
     name: Clippy
@@ -43,7 +43,7 @@ jobs:
           tool: just
       - uses: Swatinem/rust-cache@v2.9.1
       - name: Check rustdocs
-        run: just check-doc
+        run: just ci::check-doc
 
   test:
     name: Test
@@ -55,4 +55,4 @@ jobs:
           tool: just
       - uses: Swatinem/rust-cache@v2.9.1
       - name: Run tests
-        run: just test-full
+        run: just ci::test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ splic/
 ├── docs/              # Documentation
 │   ├── README.md      # Language design and user-facing docs
 │   └── bs/            # Implementation notes and proposals
+├── just/              # justfile modules (ci, doc, fuzz, sanitizers)
 ├── Cargo.toml         # Workspace configuration
 └── Cargo.lock         # Dependency lock file
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,18 +66,18 @@ just compile -o <OUTPUT> <FILE>    # Compile a Splic source file to WebAssembly
 
 ### Fuzzing
 ```bash
-just fuzz-lexer-lexer       # Fuzz targets: fuzz-lexer-lexer, fuzz-lexer-token,
-just fuzz-parser-expr       #               fuzz-parser-expr, fuzz-parser-program
-just fuzz-lexer-token 5m    # Override default 60s timeout
+just fuzz::lexer-lexer       # Fuzz targets: lexer-lexer, lexer-token,
+just fuzz::parser-expr       #               parser-expr, parser-program
+just fuzz::lexer-token 5m    # Override default 60s timeout
 ```
 
 ### Reading dependency docs
 Use `cargo-doc-md` to generate Markdown documentation for workspace dependencies. Output lands in `target/doc-md/<crate>/`.
 
 ```bash
-just crate-docs -p wasm-encoder                        # Single crate
-just crate-docs -p wasm-encoder -p wasmparser          # Multiple crates
-just doc-md-full                                       # Entire workspace + all deps
+just doc::md -p wasm-encoder                        # Single crate
+just doc::md -p wasm-encoder -p wasmparser          # Multiple crates
+just doc::md-full                                   # Entire workspace + all deps
 ```
 
 Each crate gets a `target/doc-md/<crate>/index.md` with links to submodule files (e.g. `core/instructions.md`) — start there to navigate to the relevant module. Requires `cargo install cargo-doc-md`.
@@ -88,7 +88,7 @@ Each crate gets a `target/doc-md/<crate>/index.md` with links to submodule files
 - Unit tests located throughout `compiler/src/` in `test` modules (e.g., `compiler/src/lexer/test/`, `compiler/src/parser/test/`)
 - Integration tests in `compiler/tests/`
 - Uses **rstest** for parameterized tests
-- Snapshot testing with **expect-test** (diff output may show ANSI color codes which can be misleading - if colors appear in the diff, run `just update-snapshots` to regenerate snapshots and verify actual state)
+- Snapshot testing with **expect-test** (diff output may show ANSI color codes which can be misleading — if colors appear in the diff, run `just update-snapshots` to regenerate snapshots and verify actual state)
 - Fuzz tests with **bolero** in component `test` modules
 
 ### Clippy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,7 @@ All common workflow tasks are available via `just`. Run `just` to list recipes.
 
 ### CI checks (use these before committing)
 ```bash
-just ci          # Full CI: fmt check + clippy + tests (mirrors CI exactly)
-just check-fmt   # Check formatting without modifying files
+just ci::all     # Full CI: fmt check + clippy + doc check + tests (mirrors CI exactly)
 just clippy      # Run Clippy with the full lint set
 just clippy-fix  # Apply Clippy auto-fixes
 just fmt         # Format the codebase

--- a/just/ci.just
+++ b/just/ci.just
@@ -1,0 +1,19 @@
+# Check formatting without modifying files.
+check-fmt:
+    cargo fmt --all --check
+
+# Run Clippy lints.
+clippy:
+    cargo clippy --locked --workspace --all-targets
+
+# Check rustdocs for broken links and warnings.
+check-doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --all-features --document-private-items
+
+# Run tests and check for snapshot drift.
+test:
+    cargo test --locked --workspace
+    git diff --exit-code
+
+# Run all CI checks.
+all: check-fmt clippy check-doc test

--- a/just/ci.just
+++ b/just/ci.just
@@ -1,3 +1,6 @@
+# Run all CI checks.
+all: check-fmt clippy check-doc test
+
 # Check formatting without modifying files.
 check-fmt:
     cargo fmt --all --check
@@ -14,6 +17,3 @@ check-doc:
 test:
     cargo test --locked --workspace
     git diff --exit-code
-
-# Run all CI checks.
-all: check-fmt clippy check-doc test

--- a/just/doc.just
+++ b/just/doc.just
@@ -2,22 +2,19 @@
 default:
     just --list doc
 
-# Check that cargo-doc-md is installed.
-_require-doc-md:
+[private]
+require-doc-md:
     @command -v cargo-doc-md > /dev/null 2>&1 || { echo "cargo-doc-md is not installed. Run: cargo install cargo-doc-md"; exit 1; }
 
 # Generate Markdown docs for specific crates, e.g. `just doc::md -p wasm-encoder` (requires cargo-doc-md).
-md +args: _require-doc-md
+md +args: require-doc-md
     cargo doc-md --no-deps {{args}}
 
 # Generate Markdown docs for the entire workspace into target/doc-md/ (requires cargo-doc-md).
-md-full: _require-doc-md
+md-full: require-doc-md
     cargo doc-md --workspace --include-private
 
 # Generate HTML docs for the entire workspace into target/doc/ (all features, private items).
 html-full:
     cargo doc --workspace --all-features --document-private-items
 
-# Check rustdocs for broken links and warnings (used in CI).
-check:
-    RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --all-features --document-private-items

--- a/just/doc.just
+++ b/just/doc.just
@@ -6,21 +6,15 @@ default:
 _require-doc-md:
     @command -v cargo-doc-md > /dev/null 2>&1 || { echo "cargo-doc-md is not installed. Run: cargo install cargo-doc-md"; exit 1; }
 
-# Generate Markdown docs for one or more dependencies (requires cargo-doc-md).
-# Usage: just doc::md -p wasm-encoder
-# Usage: just doc::md -p wasm-encoder -p wasmparser
-# Usage: just doc::md -p wasm-encoder --include-private
+# Generate Markdown docs for specific crates, e.g. `just doc::md -p wasm-encoder` (requires cargo-doc-md).
 md +args: _require-doc-md
     cargo doc-md --no-deps {{args}}
 
-# Generate full Markdown docs for the entire workspace and all dependencies (private items).
-# Note: cargo-doc-md does not support --all-features; features reflect workspace defaults.
-# Output in target/doc-md/.
+# Generate Markdown docs for the entire workspace into target/doc-md/ (requires cargo-doc-md).
 md-full: _require-doc-md
     cargo doc-md --workspace --include-private
 
-# Generate full HTML docs for the entire workspace (all features, private items).
-# Output in target/doc/.
+# Generate HTML docs for the entire workspace into target/doc/ (all features, private items).
 html-full:
     cargo doc --workspace --all-features --document-private-items
 

--- a/just/doc.just
+++ b/just/doc.just
@@ -1,3 +1,7 @@
+[private]
+default:
+    just --list doc
+
 # Check that cargo-doc-md is installed.
 _require-doc-md:
     @command -v cargo-doc-md > /dev/null 2>&1 || { echo "cargo-doc-md is not installed. Run: cargo install cargo-doc-md"; exit 1; }

--- a/just/doc.just
+++ b/just/doc.just
@@ -1,0 +1,25 @@
+# Check that cargo-doc-md is installed.
+_require-doc-md:
+    @command -v cargo-doc-md > /dev/null 2>&1 || { echo "cargo-doc-md is not installed. Run: cargo install cargo-doc-md"; exit 1; }
+
+# Generate Markdown docs for one or more dependencies (requires cargo-doc-md).
+# Usage: just doc::md -p wasm-encoder
+# Usage: just doc::md -p wasm-encoder -p wasmparser
+# Usage: just doc::md -p wasm-encoder --include-private
+md +args: _require-doc-md
+    cargo doc-md --no-deps {{args}}
+
+# Generate full Markdown docs for the entire workspace and all dependencies (private items).
+# Note: cargo-doc-md does not support --all-features; features reflect workspace defaults.
+# Output in target/doc-md/.
+md-full: _require-doc-md
+    cargo doc-md --workspace --include-private
+
+# Generate full HTML docs for the entire workspace (all features, private items).
+# Output in target/doc/.
+html-full:
+    cargo doc --workspace --all-features --document-private-items
+
+# Check rustdocs for broken links and warnings (used in CI).
+check:
+    RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --all-features --document-private-items

--- a/just/fuzz.just
+++ b/just/fuzz.just
@@ -1,0 +1,17 @@
+bolero := "cargo +nightly bolero test -p splic-compiler"
+
+# Fuzz the lexer against arbitrary strings.
+lexer-lexer timeout="60s":
+    {{bolero}} -T {{timeout}} lexer::test::fuzz::lexer
+
+# Fuzz the lexer against a single token.
+lexer-token timeout="60s":
+    {{bolero}} -T {{timeout}} lexer::test::fuzz::token
+
+# Fuzz the parser's expression entrypoint.
+parser-expr timeout="60s":
+    {{bolero}} -T {{timeout}} parser::test::fuzz_parse_expr
+
+# Fuzz the parser's program entrypoint.
+parser-program timeout="60s":
+    {{bolero}} -T {{timeout}} parser::test::fuzz_parse_program

--- a/just/fuzz.just
+++ b/just/fuzz.just
@@ -1,3 +1,7 @@
+[private]
+default:
+    just --list fuzz
+
 bolero := "cargo +nightly bolero test -p splic-compiler"
 
 # Fuzz the lexer against arbitrary strings.

--- a/just/sanitizers.just
+++ b/just/sanitizers.just
@@ -1,0 +1,7 @@
+# Run under Miri to detect undefined behavior and memory leaks.
+miri:
+    MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test --quiet -p splic-compiler -- --test-threads=1
+
+# Run under LeakSanitizer to detect memory leaks.
+lsan:
+    RUSTFLAGS="-Zsanitizer=leak" cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu -p splic-compiler

--- a/just/sanitizers.just
+++ b/just/sanitizers.just
@@ -1,3 +1,7 @@
+[private]
+default:
+    just --list sanitizers
+
 # Run under Miri to detect undefined behavior and memory leaks.
 miri:
     MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test --quiet -p splic-compiler -- --test-threads=1

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ mod fuzz 'just/fuzz.just'
 mod sanitizers 'just/sanitizers.just'
 
 # `default` must remain at the top.
-# List all available recipes.
+[private]
 default:
     just --list
 

--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
+mod doc 'just/doc.just'
+mod fuzz 'just/fuzz.just'
+mod sanitizers 'just/sanitizers.just'
+
 # `default` must remain at the top.
 # List all available recipes.
 default:
@@ -29,26 +33,7 @@ test-full: test
 
 # Regenerate expect-test snapshots.
 update-snapshots:
-    cargo clean -p splic-compiler -p splic-driver
     UPDATE_EXPECT=1 cargo test --locked --workspace
-
-bolero := "cargo +nightly bolero test -p splic-compiler"
-
-# Fuzz the lexer against arbitrary strings.
-fuzz-lexer-lexer timeout="60s":
-    {{bolero}} -T {{timeout}} lexer::test::fuzz::lexer
-
-# Fuzz the lexer against a single token.
-fuzz-lexer-token timeout="60s":
-    {{bolero}} -T {{timeout}} lexer::test::fuzz::token
-
-# Fuzz the parser's expression entrypoint.
-fuzz-parser-expr timeout="60s":
-    {{bolero}} -T {{timeout}} parser::test::fuzz_parse_expr
-
-# Fuzz the parser's program entrypoint.
-fuzz-parser-program timeout="60s":
-    {{bolero}} -T {{timeout}} parser::test::fuzz_parse_program
 
 # Stage a Splic source file, printing the object-level program.
 stage *args:
@@ -58,39 +43,5 @@ stage *args:
 compile *args:
     cargo run -- compile --target wasm {{args}}
 
-# Run under Miri to detect undefined behavior and memory leaks.
-miri:
-    MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test --quiet -p splic-compiler -- --test-threads=1
-
-# Run under LeakSanitizer to detect memory leaks.
-lsan:
-    RUSTFLAGS="-Zsanitizer=leak" cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu -p splic-compiler
-
-# Check that cargo-doc-md is installed.
-_require-doc-md:
-    @command -v cargo-doc-md > /dev/null 2>&1 || { echo "cargo-doc-md is not installed. Run: cargo install cargo-doc-md"; exit 1; }
-
-# Generate Markdown docs for one or more dependencies (requires cargo-doc-md).
-# Usage: just crate-docs -p wasm-encoder
-# Usage: just crate-docs -p wasm-encoder -p wasmparser
-# Usage: just crate-docs -p wasm-encoder --include-private
-crate-docs +args: _require-doc-md
-    cargo doc-md --no-deps {{args}}
-
-# Generate full HTML docs for the entire workspace and all dependencies (all features, private items).
-# Output in target/doc/.
-doc-full:
-    cargo doc --workspace --all-features --document-private-items
-
-# Generate full Markdown docs for the entire workspace and all dependencies (private items).
-# Note: cargo-doc-md does not support --all-features; features reflect workspace defaults.
-# Output in target/doc-md/.
-doc-md-full: _require-doc-md
-    cargo doc-md --workspace --include-private
-
-# Check rustdocs for broken links and warnings (used in CI).
-check-doc:
-    RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --all-features --document-private-items
-
 # Run all CI checks.
-ci: check-fmt clippy check-doc test
+ci: check-fmt clippy doc::check test

--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+# CI checks (fmt, lint, doc, test).
+mod ci 'just/ci.just'
+
 # Documentation generation and checking.
 mod doc 'just/doc.just'
 
@@ -16,13 +19,8 @@ default:
 fmt:
     cargo fmt --all
 
-# Check formatting without modifying files (used in CI).
-check-fmt:
-    cargo fmt --all --check
-
 # Run Clippy lints.
-clippy:
-    cargo clippy --locked --workspace --all-targets
+clippy: ci::clippy
 
 # Apply Clippy auto-fixes.
 clippy-fix:
@@ -31,10 +29,6 @@ clippy-fix:
 # Run tests.
 test:
     cargo test --locked --workspace
-
-# Run tests and check for snapshot drift (used in CI).
-test-full: test
-    git diff --exit-code
 
 # Regenerate expect-test snapshots.
 update-snapshots:
@@ -47,6 +41,3 @@ stage *args:
 # Compile a Splic source file to WebAssembly.
 compile *args:
     cargo run -- compile --target wasm {{args}}
-
-# Run all CI checks.
-ci: check-fmt clippy doc::check test

--- a/justfile
+++ b/justfile
@@ -1,5 +1,10 @@
+# Documentation generation and checking.
 mod doc 'just/doc.just'
+
+# Fuzz testing via bolero.
 mod fuzz 'just/fuzz.just'
+
+# Run under Miri or sanitizers.
 mod sanitizers 'just/sanitizers.just'
 
 # `default` must remain at the top.


### PR DESCRIPTION
Move fuzz, doc, and sanitizer recipes into just/ subdirectory modules. Also drop the now-unnecessary cargo clean from update-snapshots.