### PR TITLE
chore: migrate cfg_if::cfg_if! to std cfg_select!

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - run: rustup update 1.95 && rustup component add rustfmt --toolchain 1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -27,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - run: rustup update 1.95 && rustup component add clippy --toolchain 1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -40,7 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - run: rustup update 1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -53,7 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - run: rustup update 1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.95
-        with:
-          components: rustfmt
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -29,9 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.95
-        with:
-          components: clippy
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -44,9 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.95
-        with:
-          components: rust-docs
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -59,7 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@1.95
+        with:
+          components: rustfmt
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -28,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@1.95
+        with:
+          components: clippy
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -41,6 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@1.95
+        with:
+          components: rust-docs
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTUP_TOOLCHAIN: 1.95
 
 jobs:
   fmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - run: rustup component add rustfmt
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -27,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - run: rustup component add clippy
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - run: rustup update 1.95 && rustup component add rustfmt --toolchain 1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -26,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - run: rustup update 1.95 && rustup component add clippy --toolchain 1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -38,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - run: rustup update 1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -50,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - run: rustup update 1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - uses: dtolnay/rust-toolchain@1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -26,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - uses: dtolnay/rust-toolchain@1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -38,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - uses: dtolnay/rust-toolchain@1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just
@@ -50,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - uses: dtolnay/rust-toolchain@1.95
       - uses: taiki-e/install-action@v2.75.28
         with:
           tool: just

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ The project enforces a curated set of lints beyond Clippy defaults — see `[wor
 - Prefer a local `Bump::new()` over accepting an arena parameter when all allocations are scratch temporaries that do not escape the function (e.g. intermediate structures used only for a comparison that returns a non-arena type)
 
 ### Feature Gating
-- Use `cfg_if::cfg_if!` for if/else feature dispatch (not paired `#[cfg]` / `#[cfg(not(...))]` attributes)
+- Use `cfg_select!` for if/else feature dispatch (not paired `#[cfg]` / `#[cfg(not(...))]` attributes)
 - Concentrate feature checks in a dedicated helper function; avoid `#[cfg]` on enum variants or match arms — the scattered approach triggers cascading lint failures (`used_underscore_binding`, `needless_pass_by_value`, `unused_variables`)
 
 ### Trait Implementations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bumpalo",
- "cfg-if",
  "expect-test",
  "rstest",
  "splic-backend-wasm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "3"
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
+rust-version = "1.95"
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
@@ -13,7 +14,6 @@ bumpalo = { version = "3", default-features = false }
 derive_more = { version = "2", default-features = false }
 ref-cast = "1"
 bolero = "0.13"
-cfg-if = "1"
 wasm-encoder = { version = "0.248", default-features = false }
 wasmparser = { version = "0.248", default-features = false, features = ["validate"] }
 clap = { version = "4", features = ["derive"] }

--- a/backend/wasm/Cargo.toml
+++ b/backend/wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "splic-backend-wasm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "splic-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -3,6 +3,7 @@ name = "splic-compiler"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -12,7 +12,6 @@ backend-wasm = ["dep:splic-backend-wasm"]
 
 [dependencies]
 splic-compiler = { path = "../compiler" }
-cfg-if.workspace = true
 splic-backend-wasm = { path = "../backend/wasm", optional = true }
 anyhow.workspace = true
 bumpalo.workspace = true

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -3,6 +3,7 @@ name = "splic-driver"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -46,10 +46,11 @@ pub fn compile(source: &str, target: Target) -> Result<Vec<u8>> {
 ///
 /// Returns an error if the `backend-wasm` feature is not enabled.
 fn compile_wasm(program: &core::Program<'_, '_>) -> Result<Vec<u8>> {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "backend-wasm")] {
+    cfg_select! {
+        feature = "backend-wasm" => {
             splic_backend_wasm::compile_wasm(program)
-        } else {
+        }
+        _ => {
             let _ = program;
             anyhow::bail!("Wasm backend not enabled; recompile with --features backend-wasm")
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.95"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.95"
-components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.95"


### PR DESCRIPTION
- Replace cfg_if::cfg_if! with cfg_select! in driver/src/lib.rs
- Remove cfg-if dependency from workspace and driver
- Update CLAUDE.md to reference cfg_select! instead of cfg_if::cfg_if!
- Document minimum Rust version requirement (1.95+)

cfg_select! was stabilized in Rust 1.95 and provides a cleaner alternative for compile-time code selection without an external dependency.

* fixes #84 